### PR TITLE
refactor: replace assignment with field declaration

### DIFF
--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/BeurteilungResidualstatusVsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/BeurteilungResidualstatusVsLookup.java
@@ -16,7 +16,7 @@ public class BeurteilungResidualstatusVsLookup {
         }
       };
 
-  public final String lookupBeurteilungResidualstatusDisplay(String code) {
+  public final String lookupDisplay(String code) {
     return lookup.get(code);
   }
 }

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/BeurteilungResidualstatusVsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/BeurteilungResidualstatusVsLookup.java
@@ -4,21 +4,17 @@ import java.util.HashMap;
 
 public class BeurteilungResidualstatusVsLookup {
 
-  private final HashMap<String, String> lookup;
-
-  public BeurteilungResidualstatusVsLookup() {
-    lookup =
-        new HashMap<>() {
-          {
-            put("RX", "Vorhandensein von Residualtumor kann nicht beurteilt werden");
-            put("R0", "kein Residualtumor");
-            put("R1", "Mikroskopischer Residualtumor");
-            put("R1(is)", "In-Situ-Rest");
-            put("R1(cy+)", "Cytologischer Rest");
-            put("R2", "Makroskopischer Residualtumor");
-          }
-        };
-  }
+  private static final HashMap<String, String> lookup =
+      new HashMap<>() {
+        {
+          put("RX", "Vorhandensein von Residualtumor kann nicht beurteilt werden");
+          put("R0", "kein Residualtumor");
+          put("R1", "Mikroskopischer Residualtumor");
+          put("R1(is)", "In-Situ-Rest");
+          put("R1(cy+)", "Cytologischer Rest");
+          put("R2", "Makroskopischer Residualtumor");
+        }
+      };
 
   public final String lookupBeurteilungResidualstatusDisplay(String code) {
     return lookup.get(code);

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/DisplayAdtSeitenlokalisationLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/DisplayAdtSeitenlokalisationLookup.java
@@ -3,23 +3,19 @@ package org.miracum.streams.ume.obdstofhir.lookup;
 import java.util.HashMap;
 
 public class DisplayAdtSeitenlokalisationLookup {
-  private final HashMap<String, String> lookup;
-
-  public DisplayAdtSeitenlokalisationLookup() {
-    lookup =
-        new HashMap<>() {
-          {
-            put("L", "links");
-            put("R", "rechts");
-            put("B", "beidseitig (sollte bei bestimmten Tumoren 2 Meldungen ergeben)");
-            put("M", "Mittellinie/Mittig");
-            put(
-                "T",
-                "trifft nicht zu (Seitenangabe nicht sinnvoll, einschließlich Systemerkrankungen)");
-            put("U", "unbekannt");
-          }
-        };
-  }
+  private static final HashMap<String, String> lookup =
+      new HashMap<>() {
+        {
+          put("L", "links");
+          put("R", "rechts");
+          put("B", "beidseitig (sollte bei bestimmten Tumoren 2 Meldungen ergeben)");
+          put("M", "Mittellinie/Mittig");
+          put(
+              "T",
+              "trifft nicht zu (Seitenangabe nicht sinnvoll, einschließlich Systemerkrankungen)");
+          put("U", "unbekannt");
+        }
+      };
 
   public final String lookupAdtSeitenlokalisationDisplay(String code) {
     return lookup.get(code);

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/DisplayAdtSeitenlokalisationLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/DisplayAdtSeitenlokalisationLookup.java
@@ -17,7 +17,7 @@ public class DisplayAdtSeitenlokalisationLookup {
         }
       };
 
-  public final String lookupAdtSeitenlokalisationDisplay(String code) {
+  public final String lookupDisplay(String code) {
     return lookup.get(code);
   }
 }

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/FMLokalisationVsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/FMLokalisationVsLookup.java
@@ -3,27 +3,23 @@ package org.miracum.streams.ume.obdstofhir.lookup;
 import java.util.HashMap;
 
 public class FMLokalisationVsLookup {
-  private final HashMap<String, String> lookup;
-
-  public FMLokalisationVsLookup() {
-    lookup =
-        new HashMap<>() {
-          {
-            put("PUL", "Lunge");
-            put("OSS", "Knochen");
-            put("HEP", "Leber");
-            put("BRA", "Hirn");
-            put("LYM", "Lymphknoten");
-            put("MAR", "Knochenmark");
-            put("PLE", "Pleura");
-            put("PER", "Peritoneum");
-            put("ADR", "Nebennieren");
-            put("SKI", "Haut");
-            put("OTH", "Andere Organe");
-            put("GEN", "Generalisierte Metastasierung");
-          }
-        };
-  }
+  private static final HashMap<String, String> lookup =
+      new HashMap<>() {
+        {
+          put("PUL", "Lunge");
+          put("OSS", "Knochen");
+          put("HEP", "Leber");
+          put("BRA", "Hirn");
+          put("LYM", "Lymphknoten");
+          put("MAR", "Knochenmark");
+          put("PLE", "Pleura");
+          put("PER", "Peritoneum");
+          put("ADR", "Nebennieren");
+          put("SKI", "Haut");
+          put("OTH", "Andere Organe");
+          put("GEN", "Generalisierte Metastasierung");
+        }
+      };
 
   public final String lookupFMLokalisationVSDisplay(String code) {
     return lookup.get(code);

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/FMLokalisationVsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/FMLokalisationVsLookup.java
@@ -21,7 +21,7 @@ public class FMLokalisationVsLookup {
         }
       };
 
-  public final String lookupFMLokalisationVSDisplay(String code) {
+  public final String lookupDisplay(String code) {
     return lookup.get(code);
   }
 }

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/GradingLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/GradingLookup.java
@@ -4,27 +4,23 @@ import java.util.HashMap;
 
 public class GradingLookup {
 
-  private final HashMap<String, String> lookup;
-
-  public GradingLookup() {
-    lookup =
-        new HashMap<>() {
-          {
-            put("0", "malignes Melanom der Konjunktiva");
-            put("1", "gut differenziert");
-            put("2", "mäßig differenziert");
-            put("3", "schlecht differenziert");
-            put("4", "undifferenziert");
-            put("X", "nicht bestimmbar");
-            put("L", "low grade (G1 oder G2)");
-            put("M", "intermediate (G2 oder G3)");
-            put("H", "high grade (G3 oder G4)");
-            put("B", "Borderline");
-            put("U", "unbekannt");
-            put("T", "trifft nicht zu");
-          }
-        };
-  }
+  private static final HashMap<String, String> lookup =
+      new HashMap<>() {
+        {
+          put("0", "malignes Melanom der Konjunktiva");
+          put("1", "gut differenziert");
+          put("2", "mäßig differenziert");
+          put("3", "schlecht differenziert");
+          put("4", "undifferenziert");
+          put("X", "nicht bestimmbar");
+          put("L", "low grade (G1 oder G2)");
+          put("M", "intermediate (G2 oder G3)");
+          put("H", "high grade (G3 oder G4)");
+          put("B", "Borderline");
+          put("U", "unbekannt");
+          put("T", "trifft nicht zu");
+        }
+      };
 
   public final String lookupGradingDisplay(String code) {
     return lookup.get(code);

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/GradingLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/GradingLookup.java
@@ -22,7 +22,7 @@ public class GradingLookup {
         }
       };
 
-  public final String lookupGradingDisplay(String code) {
+  public final String lookupDisplay(String code) {
     return lookup.get(code);
   }
 }

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/JnuVsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/JnuVsLookup.java
@@ -3,18 +3,14 @@ package org.miracum.streams.ume.obdstofhir.lookup;
 import java.util.HashMap;
 
 public class JnuVsLookup {
-  private final HashMap<String, String> lookup;
-
-  public JnuVsLookup() {
-    lookup =
-        new HashMap<>() {
-          {
-            put("J", "Ja");
-            put("N", "Nein");
-            put("U", "unbekannt");
-          }
-        };
-  }
+  private static final HashMap<String, String> lookup =
+      new HashMap<>() {
+        {
+          put("J", "Ja");
+          put("N", "Nein");
+          put("U", "unbekannt");
+        }
+      };
 
   public final String lookupJnuDisplay(String code) {
     return lookup.get(code);

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/JnuVsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/JnuVsLookup.java
@@ -12,7 +12,7 @@ public class JnuVsLookup {
         }
       };
 
-  public final String lookupJnuDisplay(String code) {
+  public final String lookupDisplay(String code) {
     return lookup.get(code);
   }
 }

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/OPIntentionVsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/OPIntentionVsLookup.java
@@ -16,7 +16,7 @@ public class OPIntentionVsLookup {
         }
       };
 
-  public final String lookupOPIntentionVSDisplay(String code) {
+  public final String lookupDisplay(String code) {
     return lookup.get(code);
   }
 }

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/OPIntentionVsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/OPIntentionVsLookup.java
@@ -4,21 +4,17 @@ import java.util.HashMap;
 
 public class OPIntentionVsLookup {
 
-  private final HashMap<String, String> lookup;
-
-  public OPIntentionVsLookup() {
-    lookup =
-        new HashMap<>() {
-          {
-            put("K", "kurativ");
-            put("P", "palliativ");
-            put("D", "diagnostisch");
-            put("R", "Revision/Komplikation");
-            put("S", "sonstiges");
-            put("X", "Fehlende Angabe");
-          }
-        };
-  }
+  private static final HashMap<String, String> lookup =
+      new HashMap<>() {
+        {
+          put("K", "kurativ");
+          put("P", "palliativ");
+          put("D", "diagnostisch");
+          put("R", "Revision/Komplikation");
+          put("S", "sonstiges");
+          put("X", "Fehlende Angabe");
+        }
+      };
 
   public final String lookupOPIntentionVSDisplay(String code) {
     return lookup.get(code);

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/OPKomplikationVsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/OPKomplikationVsLookup.java
@@ -94,7 +94,7 @@ public class OPKomplikationVsLookup {
         }
       };
 
-  public final String lookupOPKomplikationVSDisplay(String code) {
+  public final String lookupDisplay(String code) {
     return lookup.get(code);
   }
 }

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/OPKomplikationVsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/OPKomplikationVsLookup.java
@@ -4,99 +4,95 @@ import java.util.HashMap;
 
 public class OPKomplikationVsLookup {
 
-  private final HashMap<String, String> lookup;
-
-  public OPKomplikationVsLookup() {
-    lookup =
-        new HashMap<>() {
-          {
-            put("N", "Nein");
-            put("U", "Unbekannt");
-            put("ABD", "Abszeß in einem Drainagekanal");
-            put("ABS", "Abszeß, intraabdominaler oder intrathorakaler");
-            put("ASF", "Abszeß, subfaszialer");
-            put("ANI", "Akute Niereninsuffizienz");
-            put("AEP", "Alkoholentzugspsychose");
-            put("ALR", "Allergische Reaktion ohne Schocksymptomatik");
-            put("ANS", "Anaphylaktischer Schock");
-            put("AEE", "Anastomoseninsuffizienz einer Enterostomie");
-            put("API", "Apoplektischer Insult");
-            put("BIF", "Biliäre Fistel");
-            put("BOG", "Blutung, obere gastrointestinale (z.B \"Stressulkus\")");
-            put("BOE", "Bolusverlegung eines Endotubus");
-            put("BSI", "Bronchusstumpfinsuffizienz");
-            put("CHI", "Cholangitis");
-            put("DAI", "Darmanastomoseinsuffizienz");
-            put("DPS", "Darmpassagestörungen (z.B. protrahierte Atonie, Subileus, Ileus)");
-            put("DIC", "Disseminierte intravasale Koagulopathie");
-            put("DEP", "Drogenentzugspsychose");
-            put("DLU", "Druck- und Lagerungsschäden, z.B. Dekubitalulzera");
-            put("DSI", "Duodenalstumpfinsuffizienz");
-            put("ENF", "Enterale Fistel");
-            put("GER", "Gerinnungsstörung");
-            put("HEM", "Hämatemesis");
-            put("HUR", "Hämaturie");
-            put("HAE", "Hämorrhagischer Schock");
-            put("HFI", "Harnfistel");
-            put("HNK", "Hautnekrose im Operationsbereich");
-            put("HZI", "Herzinsuffizienz");
-            put("HRS", "Herzrhythmusstörungen");
-            put("HNA", "Hirnnervenausfälle");
-            put("HOP", "Hirnorganisches Psychosyndrom (z.B. \"Durchgangssyndrom\")");
-            put("HYB", "Hyperbilirubinämie");
-            put("HYF", "Hypopharynxfistel");
-            put("IFV", "Ileofemorale Venenthrombose");
-            put("KAS", "Kardiogener Schock");
-            put("KES", "Komplikationen einer Stomaanlage");
-            put(
-                "KIM",
-                "Komplikation eines Implantates (Gefäßprothese, Totalendoprothese, Katheter), z.B. Dislokation");
-            put("KRA", "Krampfanfall");
-            put("KDS", "Kurzdarmsyndrom");
-            put("LEV", "Leberversagen");
-            put("LOE", "Lungenödem");
-            put("LYF", "Lymphfistel");
-            put("LYE", "Lymphozele");
-            put("MES", "Magenentleerungsstörung");
-            put("MIL", "Mechanischer Ileus");
-            put("MED", "Mediastinitis");
-            put("MAT", "Mesenterialarterien- oder -venenthrombose");
-            put("MYI", "Myokardinfarkt");
-            put("RNB", "Nachblutung, revisionsbedürftig, anderweitig nicht erwähnt");
-            put("NAB", "Nachblutung, nicht revisionsbedürftig, anderweitig nicht erwähnt");
-            put("NIN", "Nahtinsuffizienz, anderweitig nicht erwähnt");
-            put("OES", "Ösophagitis");
-            put("OSM", "Osteitis, Osteomyelitis");
-            put("PAF", "Pankreasfistel");
-            put("PIT", "Pankreatitis");
-            put("PAB", "Peranale Blutung");
-            put("PPA", "Periphere Parese");
-            put("PAV", "Peripherer arterieller Verschluß (Embolie, Thrombose)");
-            put("PER", "Peritonitis");
-            put("PLB", "Platzbauch");
-            put("PEY", "Pleuraempyem");
-            put("PLE", "Pleuraerguß");
-            put("PMN", "Pneumonie");
-            put("PNT", "Pneumothorax");
-            put("PDA", "Protrahierte Darmatonie (paralytischer Ileus)");
-            put("PAE", "Pulmonalarterienembolie");
-            put("RPA", "Rekurrensparese");
-            put("RIN", "Respiratorische Insuffizienz");
-            put("SKI", "Septische Komplikation eines Implantates");
-            put("SES", "Septischer Schock");
-            put("SFH", "Störungen des Flüssigkeits-, Elektrolyt- und Säurebasenhaushaltes");
-            put("SON", "Sonstige Komplikation");
-            put("STK", "Stomakomplikation (z.B. Blutung, Nekrose, Stenose)");
-            put("TZP", "Thrombozytopenie");
-            put(
-                "TIA",
-                "TIA (transitorische ischämische Attacke) oder RIND (reversibles ischämisches neurologisches Defizit)");
-            put("TRZ", "Transfusionszwischenfall");
-            put("WUH", "Wundhämatom (konservativ therapiert)");
-            put("WSS", "Wundheilungsstörung, subkutane");
-          }
-        };
-  }
+  private static final HashMap<String, String> lookup =
+      new HashMap<>() {
+        {
+          put("N", "Nein");
+          put("U", "Unbekannt");
+          put("ABD", "Abszeß in einem Drainagekanal");
+          put("ABS", "Abszeß, intraabdominaler oder intrathorakaler");
+          put("ASF", "Abszeß, subfaszialer");
+          put("ANI", "Akute Niereninsuffizienz");
+          put("AEP", "Alkoholentzugspsychose");
+          put("ALR", "Allergische Reaktion ohne Schocksymptomatik");
+          put("ANS", "Anaphylaktischer Schock");
+          put("AEE", "Anastomoseninsuffizienz einer Enterostomie");
+          put("API", "Apoplektischer Insult");
+          put("BIF", "Biliäre Fistel");
+          put("BOG", "Blutung, obere gastrointestinale (z.B \"Stressulkus\")");
+          put("BOE", "Bolusverlegung eines Endotubus");
+          put("BSI", "Bronchusstumpfinsuffizienz");
+          put("CHI", "Cholangitis");
+          put("DAI", "Darmanastomoseinsuffizienz");
+          put("DPS", "Darmpassagestörungen (z.B. protrahierte Atonie, Subileus, Ileus)");
+          put("DIC", "Disseminierte intravasale Koagulopathie");
+          put("DEP", "Drogenentzugspsychose");
+          put("DLU", "Druck- und Lagerungsschäden, z.B. Dekubitalulzera");
+          put("DSI", "Duodenalstumpfinsuffizienz");
+          put("ENF", "Enterale Fistel");
+          put("GER", "Gerinnungsstörung");
+          put("HEM", "Hämatemesis");
+          put("HUR", "Hämaturie");
+          put("HAE", "Hämorrhagischer Schock");
+          put("HFI", "Harnfistel");
+          put("HNK", "Hautnekrose im Operationsbereich");
+          put("HZI", "Herzinsuffizienz");
+          put("HRS", "Herzrhythmusstörungen");
+          put("HNA", "Hirnnervenausfälle");
+          put("HOP", "Hirnorganisches Psychosyndrom (z.B. \"Durchgangssyndrom\")");
+          put("HYB", "Hyperbilirubinämie");
+          put("HYF", "Hypopharynxfistel");
+          put("IFV", "Ileofemorale Venenthrombose");
+          put("KAS", "Kardiogener Schock");
+          put("KES", "Komplikationen einer Stomaanlage");
+          put(
+              "KIM",
+              "Komplikation eines Implantates (Gefäßprothese, Totalendoprothese, Katheter), z.B. Dislokation");
+          put("KRA", "Krampfanfall");
+          put("KDS", "Kurzdarmsyndrom");
+          put("LEV", "Leberversagen");
+          put("LOE", "Lungenödem");
+          put("LYF", "Lymphfistel");
+          put("LYE", "Lymphozele");
+          put("MES", "Magenentleerungsstörung");
+          put("MIL", "Mechanischer Ileus");
+          put("MED", "Mediastinitis");
+          put("MAT", "Mesenterialarterien- oder -venenthrombose");
+          put("MYI", "Myokardinfarkt");
+          put("RNB", "Nachblutung, revisionsbedürftig, anderweitig nicht erwähnt");
+          put("NAB", "Nachblutung, nicht revisionsbedürftig, anderweitig nicht erwähnt");
+          put("NIN", "Nahtinsuffizienz, anderweitig nicht erwähnt");
+          put("OES", "Ösophagitis");
+          put("OSM", "Osteitis, Osteomyelitis");
+          put("PAF", "Pankreasfistel");
+          put("PIT", "Pankreatitis");
+          put("PAB", "Peranale Blutung");
+          put("PPA", "Periphere Parese");
+          put("PAV", "Peripherer arterieller Verschluß (Embolie, Thrombose)");
+          put("PER", "Peritonitis");
+          put("PLB", "Platzbauch");
+          put("PEY", "Pleuraempyem");
+          put("PLE", "Pleuraerguß");
+          put("PMN", "Pneumonie");
+          put("PNT", "Pneumothorax");
+          put("PDA", "Protrahierte Darmatonie (paralytischer Ileus)");
+          put("PAE", "Pulmonalarterienembolie");
+          put("RPA", "Rekurrensparese");
+          put("RIN", "Respiratorische Insuffizienz");
+          put("SKI", "Septische Komplikation eines Implantates");
+          put("SES", "Septischer Schock");
+          put("SFH", "Störungen des Flüssigkeits-, Elektrolyt- und Säurebasenhaushaltes");
+          put("SON", "Sonstige Komplikation");
+          put("STK", "Stomakomplikation (z.B. Blutung, Nekrose, Stenose)");
+          put("TZP", "Thrombozytopenie");
+          put(
+              "TIA",
+              "TIA (transitorische ischämische Attacke) oder RIND (reversibles ischämisches neurologisches Defizit)");
+          put("TRZ", "Transfusionszwischenfall");
+          put("WUH", "Wundhämatom (konservativ therapiert)");
+          put("WSS", "Wundheilungsstörung, subkutane");
+        }
+      };
 
   public final String lookupOPKomplikationVSDisplay(String code) {
     return lookup.get(code);

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SYSTTherapieartCSLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SYSTTherapieartCSLookup.java
@@ -7,43 +7,37 @@ import java.util.List;
 
 public class SYSTTherapieartCSLookup {
 
-  private final HashMap<String, String> lookup;
+  private static final HashMap<String, String> lookup =
+      new HashMap<>() {
+        {
+          put("CH", "Chemotherapie");
+          put("HO", "Hormontherapie");
+          put("IM", "Immun- und Antikörpertherapie");
+          put("KM", "Knochenmarkstransplantation");
+          put("WS", "Wait and see");
+          put("AS", "Active Surveillance");
+          put("ZS", "Zielgerichtete Substanzen");
+          put("SO", "Sonstiges");
+          put("ST", "Strahlentherapie");
+          put("OP", "Operation");
+          put("CI", "Chemo- + Immun-/Antikörpertherapie");
+          put("CZ", "Chemotherapie + zielgerichtete Substanzen");
+          put("CIZ", "Chemo- + Immun-/Antikörpertherapie + zielgerichtete Substanzen");
+          put("IZ", "Immun-/Antikörpertherapie + zielgerichtete Substanzen");
+          put("SZ", "Stammzelltransplantation (inkl. Knochenmarktransplantation)");
+          put("WW", "Watchful Waiting");
+        }
+      };
 
-  private final HashMap<String, String> multipleKeyLookup;
-
-  public SYSTTherapieartCSLookup() {
-    lookup =
-        new HashMap<>() {
-          {
-            put("CH", "Chemotherapie");
-            put("HO", "Hormontherapie");
-            put("IM", "Immun- und Antikörpertherapie");
-            put("KM", "Knochenmarkstransplantation");
-            put("WS", "Wait and see");
-            put("AS", "Active Surveillance");
-            put("ZS", "Zielgerichtete Substanzen");
-            put("SO", "Sonstiges");
-            put("ST", "Strahlentherapie");
-            put("OP", "Operation");
-            put("CI", "Chemo- + Immun-/Antikörpertherapie");
-            put("CZ", "Chemotherapie + zielgerichtete Substanzen");
-            put("CIZ", "Chemo- + Immun-/Antikörpertherapie + zielgerichtete Substanzen");
-            put("IZ", "Immun-/Antikörpertherapie + zielgerichtete Substanzen");
-            put("SZ", "Stammzelltransplantation (inkl. Knochenmarktransplantation)");
-            put("WW", "Watchful Waiting");
-          }
-        };
-
-    multipleKeyLookup =
-        new HashMap<>() {
-          {
-            put("CHIM", "CI");
-            put("CHZS", "CZ");
-            put("CHIMZS", "CIZ");
-            put("IMZS", "IZ");
-          }
-        };
-  }
+  private static final HashMap<String, String> multipleKeyLookup =
+      new HashMap<>() {
+        {
+          put("CHIM", "CI");
+          put("CHZS", "CZ");
+          put("CHIMZS", "CIZ");
+          put("IMZS", "IZ");
+        }
+      };
 
   public final String lookupSYSTTherapieartCSLookupDisplay(List<String> code) {
 

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SYSTTherapieartCSLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SYSTTherapieartCSLookup.java
@@ -39,7 +39,7 @@ public class SYSTTherapieartCSLookup {
         }
       };
 
-  public final String lookupSYSTTherapieartCSLookupDisplay(List<String> code) {
+  public final String lookupDisplay(List<String> code) {
 
     if (code.size() == 1) {
       return lookup.get(code.get(0));
@@ -50,7 +50,7 @@ public class SYSTTherapieartCSLookup {
     }
   }
 
-  public final String lookupSYSTTherapieartCSLookupCode(List<String> code) {
+  public final String lookupCode(List<String> code) {
 
     if (code.size() == 1) {
       return code.get(0);

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SideEffectTherapyGradingLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SideEffectTherapyGradingLookup.java
@@ -16,11 +16,11 @@ public class SideEffectTherapyGradingLookup {
         }
       };
 
-  public final String lookupSideEffectTherapyGradingCode(String code) {
+  public final String lookupCode(String code) {
     return lookup.get(code) != null ? lookup.get(code).get(0) : null;
   }
 
-  public final String lookupSideEffectTherapyGradingDisplay(String code) {
+  public final String lookupDisplay(String code) {
     return lookup.get(code) != null ? lookup.get(code).get(1) : null;
   }
 }

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SideEffectTherapyGradingLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SideEffectTherapyGradingLookup.java
@@ -4,21 +4,17 @@ import java.util.HashMap;
 import java.util.List;
 
 public class SideEffectTherapyGradingLookup {
-  private final HashMap<String, List<String>> lookup;
-
-  public SideEffectTherapyGradingLookup() {
-    lookup =
-        new HashMap<>() {
-          {
-            put("K", List.of("0", "keine"));
-            put("1", List.of("1", "mild"));
-            put("2", List.of("2", "moderat"));
-            put("3", List.of("3", "schwerwiegend"));
-            put("4", List.of("4", "lebensbedrohlich"));
-            put("5", List.of("5", "tödlich"));
-          }
-        };
-  }
+  private static final HashMap<String, List<String>> lookup =
+      new HashMap<>() {
+        {
+          put("K", List.of("0", "keine"));
+          put("1", List.of("1", "mild"));
+          put("2", List.of("2", "moderat"));
+          put("3", List.of("3", "schwerwiegend"));
+          put("4", List.of("4", "lebensbedrohlich"));
+          put("5", List.of("5", "tödlich"));
+        }
+      };
 
   public final String lookupSideEffectTherapyGradingCode(String code) {
     return lookup.get(code) != null ? lookup.get(code).get(0) : null;

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SnomedCtSeitenlokalisationLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SnomedCtSeitenlokalisationLookup.java
@@ -4,21 +4,17 @@ import java.util.HashMap;
 import java.util.List;
 
 public class SnomedCtSeitenlokalisationLookup {
-  private final HashMap<String, List<String>> lookup;
-
-  public SnomedCtSeitenlokalisationLookup() {
-    lookup =
-        new HashMap<>() {
-          {
-            put("L", List.of("7771000", "Left"));
-            put("R", List.of("24028007", "Right"));
-            put("B", List.of("51440002", "Right and left / Both sides"));
-            put("M", List.of("260528009", "Median"));
-            put("T", List.of("396360001", "Tumor site not applicable (finding)"));
-            put("U", List.of("87100004", "Topography unknown"));
-          }
-        };
-  }
+  private static final HashMap<String, List<String>> lookup =
+      new HashMap<>() {
+        {
+          put("L", List.of("7771000", "Left"));
+          put("R", List.of("24028007", "Right"));
+          put("B", List.of("51440002", "Right and left / Both sides"));
+          put("M", List.of("260528009", "Median"));
+          put("T", List.of("396360001", "Tumor site not applicable (finding)"));
+          put("U", List.of("87100004", "Topography unknown"));
+        }
+      };
 
   public final String lookupSnomedCode(String AdtCode) {
     return lookup.get(AdtCode) != null ? lookup.get(AdtCode).get(0) : null;

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SnomedCtSeitenlokalisationLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SnomedCtSeitenlokalisationLookup.java
@@ -16,11 +16,11 @@ public class SnomedCtSeitenlokalisationLookup {
         }
       };
 
-  public final String lookupSnomedCode(String AdtCode) {
+  public final String lookupCode(String AdtCode) {
     return lookup.get(AdtCode) != null ? lookup.get(AdtCode).get(0) : null;
   }
 
-  public final String lookupSnomedDisplay(String AdtCode) {
+  public final String lookupDisplay(String AdtCode) {
     return lookup.get(AdtCode) != null ? lookup.get(AdtCode).get(1) : null;
   }
 }

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/StellungOpVsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/StellungOpVsLookup.java
@@ -14,7 +14,7 @@ public class StellungOpVsLookup {
         }
       };
 
-  public final String lookupStellungOpDisplay(String code) {
+  public final String lookupDisplay(String code) {
     return lookup.get(code);
   }
 }

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/StellungOpVsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/StellungOpVsLookup.java
@@ -3,20 +3,16 @@ package org.miracum.streams.ume.obdstofhir.lookup;
 import java.util.HashMap;
 
 public class StellungOpVsLookup {
-  private final HashMap<String, String> lookup;
-
-  public StellungOpVsLookup() {
-    lookup =
-        new HashMap<>() {
-          {
-            put("O", "ohne Bezug zu einer operativen Therapie");
-            put("A", "adjuvant");
-            put("N", "neoadjuvant");
-            put("I", "intraoperativ");
-            put("S", "sonstiges");
-          }
-        };
-  }
+  private static final HashMap<String, String> lookup =
+      new HashMap<>() {
+        {
+          put("O", "ohne Bezug zu einer operativen Therapie");
+          put("A", "adjuvant");
+          put("N", "neoadjuvant");
+          put("I", "intraoperativ");
+          put("S", "sonstiges");
+        }
+      };
 
   public final String lookupStellungOpDisplay(String code) {
     return lookup.get(code);

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SystIntentionVsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SystIntentionVsLookup.java
@@ -13,7 +13,7 @@ public class SystIntentionVsLookup {
         }
       };
 
-  public final String lookupSystIntentionDisplay(String code) {
+  public final String lookupDisplay(String code) {
     return lookup.get(code);
   }
 }

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SystIntentionVsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/SystIntentionVsLookup.java
@@ -3,19 +3,15 @@ package org.miracum.streams.ume.obdstofhir.lookup;
 import java.util.HashMap;
 
 public class SystIntentionVsLookup {
-  private final HashMap<String, String> lookup;
-
-  public SystIntentionVsLookup() {
-    lookup =
-        new HashMap<>() {
-          {
-            put("K", "kurativ");
-            put("P", "palliativ");
-            put("S", "sonstiges");
-            put("X", "keine Angabe");
-          }
-        };
-  }
+  private static final HashMap<String, String> lookup =
+      new HashMap<>() {
+        {
+          put("K", "kurativ");
+          put("P", "palliativ");
+          put("S", "sonstiges");
+          put("X", "keine Angabe");
+        }
+      };
 
   public final String lookupSystIntentionDisplay(String code) {
     return lookup.get(code);

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/TnmCpuPraefixTvsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/TnmCpuPraefixTvsLookup.java
@@ -4,24 +4,20 @@ import java.util.HashMap;
 
 public class TnmCpuPraefixTvsLookup {
 
-  private final HashMap<String, String> lookup;
-
-  public TnmCpuPraefixTvsLookup() {
-    lookup =
-        new HashMap<>() {
-          {
-            put(
-                "c",
-                "Kategorie wurde durch klinische Angaben festgestellt, bzw. erfüllt die Kriterien für p nicht");
-            put(
-                "p",
-                "Feststellung der Kategorie erfolgte durch eine pathohistologische Untersuchung, mit der auch der höchste Grad der jeweiligen Kategorie hätte festgestellt werden können");
-            put(
-                "u",
-                "Feststellung mit Ultraschall (Unterkategorie von c mit besonderer diagnostischer Relevanz, z.B. beim Rektumkarzinom)");
-          }
-        };
-  }
+  private static final HashMap<String, String> lookup =
+      new HashMap<>() {
+        {
+          put(
+              "c",
+              "Kategorie wurde durch klinische Angaben festgestellt, bzw. erfüllt die Kriterien für p nicht");
+          put(
+              "p",
+              "Feststellung der Kategorie erfolgte durch eine pathohistologische Untersuchung, mit der auch der höchste Grad der jeweiligen Kategorie hätte festgestellt werden können");
+          put(
+              "u",
+              "Feststellung mit Ultraschall (Unterkategorie von c mit besonderer diagnostischer Relevanz, z.B. beim Rektumkarzinom)");
+        }
+      };
 
   public final String lookupTnmCpuPraefixDisplay(String code) {
     return lookup.get(code);

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/TnmCpuPraefixTvsLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/TnmCpuPraefixTvsLookup.java
@@ -19,7 +19,7 @@ public class TnmCpuPraefixTvsLookup {
         }
       };
 
-  public final String lookupTnmCpuPraefixDisplay(String code) {
+  public final String lookupDisplay(String code) {
     return lookup.get(code);
   }
 }

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsConditionMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsConditionMapper.java
@@ -133,11 +133,10 @@ public class ObdsConditionMapper extends ObdsToFhirMapper {
 
     if (adtBodySite != null) {
       var adtSeitenlokalisationDisplay =
-          displayAdtSeitenlokalisationLookup.lookupAdtSeitenlokalisationDisplay(adtBodySite);
-      var snomedCtSeitenlokalisationCode =
-          snomedCtSeitenlokalisationLookup.lookupSnomedCode(adtBodySite);
+          displayAdtSeitenlokalisationLookup.lookupDisplay(adtBodySite);
+      var snomedCtSeitenlokalisationCode = snomedCtSeitenlokalisationLookup.lookupCode(adtBodySite);
       var snomedCtSeitenlokalisationDisplay =
-          snomedCtSeitenlokalisationLookup.lookupSnomedDisplay(adtBodySite);
+          snomedCtSeitenlokalisationLookup.lookupDisplay(adtBodySite);
 
       if (adtSeitenlokalisationDisplay != null) {
         bodySiteADTCoding

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsMedicationStatementMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsMedicationStatementMapper.java
@@ -193,9 +193,8 @@ public class ObdsMedicationStatementMapper extends ObdsToFhirMapper {
       therapyCategory.addCoding(
           new Coding()
               .setSystem(fhirProperties.getSystems().getSystTherapieart())
-              .setCode(displaySystTherapieLookup.lookupSYSTTherapieartCSLookupCode(category))
-              .setDisplay(
-                  displaySystTherapieLookup.lookupSYSTTherapieartCSLookupDisplay(category)));
+              .setCode(displaySystTherapieLookup.lookupCode(category))
+              .setDisplay(displaySystTherapieLookup.lookupDisplay(category)));
 
       if (systemTherapy.getSYST_Therapieart_Anmerkung() != null) {
         therapyCategory.setText(systemTherapy.getSYST_Therapieart_Anmerkung());
@@ -219,7 +218,7 @@ public class ObdsMedicationStatementMapper extends ObdsToFhirMapper {
                         .setCode(systemTherapy.getSYST_Stellung_OP())
                         .setSystem(fhirProperties.getSystems().getSystStellungOP())
                         .setDisplay(
-                            displayStellungOpLookup.lookupStellungOpDisplay(
+                            displayStellungOpLookup.lookupDisplay(
                                 systemTherapy.getSYST_Stellung_OP()))));
 
     stMedicationStatement
@@ -232,7 +231,7 @@ public class ObdsMedicationStatementMapper extends ObdsToFhirMapper {
                         .setCode(systemTherapy.getSYST_Intention())
                         .setSystem(fhirProperties.getSystems().getSystIntention())
                         .setDisplay(
-                            displaySystIntentionLookup.lookupSystIntentionDisplay(
+                            displaySystIntentionLookup.lookupDisplay(
                                 systemTherapy.getSYST_Intention()))));
 
     stMedicationStatement

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsObservationMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsObservationMapper.java
@@ -498,7 +498,7 @@ public class ObdsObservationMapper extends ObdsToFhirMapper {
               new Coding()
                   .setSystem(fhirProperties.getSystems().getGradingDktk())
                   .setCode(grading)
-                  .setDisplay(gradingLookup.lookupGradingDisplay(grading)));
+                  .setDisplay(gradingLookup.lookupDisplay(grading)));
 
       gradingObs.setValue(gradingValueCodeableCon);
     }
@@ -644,7 +644,7 @@ public class ObdsObservationMapper extends ObdsToFhirMapper {
             new Coding()
                 .setSystem(fhirProperties.getSystems().getFMLokalisationCS())
                 .setCode(fernMetaLokal)
-                .setDisplay(fmLokalisationVSLookup.lookupFMLokalisationVSDisplay(fernMetaLokal))));
+                .setDisplay(fmLokalisationVSLookup.lookupDisplay(fernMetaLokal))));
 
     bundle = addResourceAsEntryInBundle(bundle, fernMetaObs);
 
@@ -734,7 +734,7 @@ public class ObdsObservationMapper extends ObdsToFhirMapper {
       backBoneComponentListC.add(
           createTNMComponentElement(
               cTnmCpuPraefixT,
-              tnmPraefixLookup.lookupTnmCpuPraefixDisplay(cTnmCpuPraefixT),
+              tnmPraefixLookup.lookupDisplay(cTnmCpuPraefixT),
               "21905-5",
               "Primary tumor.clinical Cancer",
               fhirProperties.getSystems().getTnmTCs(),
@@ -747,7 +747,7 @@ public class ObdsObservationMapper extends ObdsToFhirMapper {
       backBoneComponentListC.add(
           createTNMComponentElement(
               cTnmCpuPraefixN,
-              tnmPraefixLookup.lookupTnmCpuPraefixDisplay(cTnmCpuPraefixN),
+              tnmPraefixLookup.lookupDisplay(cTnmCpuPraefixN),
               "21906-3",
               "Regional lymph nodes.clinical",
               fhirProperties.getSystems().getTnmNCs(),
@@ -760,7 +760,7 @@ public class ObdsObservationMapper extends ObdsToFhirMapper {
       backBoneComponentListC.add(
           createTNMComponentElement(
               cTnmCpuPraefixM,
-              tnmPraefixLookup.lookupTnmCpuPraefixDisplay(cTnmCpuPraefixM),
+              tnmPraefixLookup.lookupDisplay(cTnmCpuPraefixM),
               "21907-1",
               "Distant metastases.clinical [Class] Cancer",
               fhirProperties.getSystems().getTnmMCs(),
@@ -894,7 +894,7 @@ public class ObdsObservationMapper extends ObdsToFhirMapper {
       backBoneComponentListP.add(
           createTNMComponentElement(
               pTnmCpuPraefixT,
-              tnmPraefixLookup.lookupTnmCpuPraefixDisplay(pTnmCpuPraefixT),
+              tnmPraefixLookup.lookupDisplay(pTnmCpuPraefixT),
               "21899-0",
               "Primary tumor.pathology Cancer",
               fhirProperties.getSystems().getTnmTCs(),
@@ -907,7 +907,7 @@ public class ObdsObservationMapper extends ObdsToFhirMapper {
       backBoneComponentListP.add(
           createTNMComponentElement(
               pTnmCpuPraefixN,
-              tnmPraefixLookup.lookupTnmCpuPraefixDisplay(pTnmCpuPraefixN),
+              tnmPraefixLookup.lookupDisplay(pTnmCpuPraefixN),
               "21900-6",
               "Regional lymph nodes.pathology",
               fhirProperties.getSystems().getTnmNCs(),
@@ -920,7 +920,7 @@ public class ObdsObservationMapper extends ObdsToFhirMapper {
       backBoneComponentListP.add(
           createTNMComponentElement(
               pTnmCpuPraefixM,
-              tnmPraefixLookup.lookupTnmCpuPraefixDisplay(pTnmCpuPraefixM),
+              tnmPraefixLookup.lookupDisplay(pTnmCpuPraefixM),
               "21901-4",
               "Distant metastases.pathology [Class] Cancer",
               fhirProperties.getSystems().getTnmMCs(),
@@ -1063,7 +1063,7 @@ public class ObdsObservationMapper extends ObdsToFhirMapper {
           new Coding()
               .setSystem(fhirProperties.getSystems().getJnuCs())
               .setCode(death.getTod_tumorbedingt())
-              .setDisplay(jnuVsLookup.lookupJnuDisplay(death.getTod_tumorbedingt()));
+              .setDisplay(jnuVsLookup.lookupDisplay(death.getTod_tumorbedingt()));
       deathValueCodeConcept.addCoding(deathByTumorCoding);
     }
 

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsProcedureMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsProcedureMapper.java
@@ -227,8 +227,7 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
                     new Coding()
                         .setCode(opIntention)
                         .setSystem(fhirProperties.getSystems().getOpIntention())
-                        .setDisplay(
-                            displayOPIntentionLookup.lookupOPIntentionVSDisplay(opIntention))));
+                        .setDisplay(displayOPIntentionLookup.lookupDisplay(opIntention))));
 
     // Status
     opProcedure.setStatus(Procedure.ProcedureStatus.COMPLETED);
@@ -240,9 +239,7 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
                 new Coding()
                     .setSystem(fhirProperties.getSystems().getSystTherapieart())
                     .setCode("OP")
-                    .setDisplay(
-                        displaySystTherapieLookup.lookupSYSTTherapieartCSLookupDisplay(
-                            List.of("OP")))));
+                    .setDisplay(displaySystTherapieLookup.lookupDisplay(List.of("OP")))));
 
     // Subject
     opProcedure.setSubject(
@@ -286,8 +283,7 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
                 .setSystem(fhirProperties.getSystems().getLokalBeurtResidualCS())
                 .setCode(lokalResidualstatus)
                 .setDisplay(
-                    displayBeurteilungResidualstatusLookup.lookupBeurteilungResidualstatusDisplay(
-                        lokalResidualstatus)));
+                    displayBeurteilungResidualstatusLookup.lookupDisplay(lokalResidualstatus)));
       }
 
       if (gesamtResidualstatus != null) {
@@ -296,8 +292,7 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
                 .setSystem(fhirProperties.getSystems().getGesamtBeurtResidualCS())
                 .setCode(gesamtResidualstatus)
                 .setDisplay(
-                    displayBeurteilungResidualstatusLookup.lookupBeurteilungResidualstatusDisplay(
-                        gesamtResidualstatus)));
+                    displayBeurteilungResidualstatusLookup.lookupDisplay(gesamtResidualstatus)));
       }
 
       if (gesamtResidualstatus != null || lokalResidualstatus != null) {
@@ -315,8 +310,7 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
             new Coding()
                 .setSystem(fhirProperties.getSystems().getOpComplication())
                 .setCode(complication)
-                .setDisplay(
-                    displayOPKomplicationLookup.lookupOPKomplikationVSDisplay(complication)));
+                .setDisplay(displayOPKomplicationLookup.lookupDisplay(complication)));
       }
       opProcedure.setComplication(List.of(complicationConcept));
     }
@@ -414,7 +408,7 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
                         .setCode(radioTherapy.getST_Stellung_OP())
                         .setSystem(fhirProperties.getSystems().getSystStellungOP())
                         .setDisplay(
-                            displayStellungOpLookup.lookupStellungOpDisplay(
+                            displayStellungOpLookup.lookupDisplay(
                                 radioTherapy.getST_Stellung_OP()))));
 
     // check if systIntention is defined in xml, otherwise set "X"
@@ -431,8 +425,7 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
                     new Coding()
                         .setCode(systIntention)
                         .setSystem(fhirProperties.getSystems().getSystIntention())
-                        .setDisplay(
-                            displaySystIntentionLookup.lookupSystIntentionDisplay(systIntention))));
+                        .setDisplay(displaySystIntentionLookup.lookupDisplay(systIntention))));
 
     // Status
     if (meldeanlass == Meldeanlass.BEHANDLUNGSENDE) {
@@ -448,9 +441,7 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
                 new Coding()
                     .setSystem(fhirProperties.getSystems().getSystTherapieart())
                     .setCode("ST")
-                    .setDisplay(
-                        displaySystTherapieLookup.lookupSYSTTherapieartCSLookupDisplay(
-                            List.of("ST")))));
+                    .setDisplay(displaySystTherapieLookup.lookupDisplay(List.of("ST")))));
 
     // Subject
     stProcedure.setSubject(
@@ -488,12 +479,8 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
         if (sideEffectGrading != null && !sideEffectGrading.equals("U")) {
           sideEffectsCodeConcept.addCoding(
               new Coding()
-                  .setCode(
-                      displaySideEffectGradingLookup.lookupSideEffectTherapyGradingCode(
-                          sideEffectGrading))
-                  .setDisplay(
-                      displaySideEffectGradingLookup.lookupSideEffectTherapyGradingDisplay(
-                          sideEffectGrading))
+                  .setCode(displaySideEffectGradingLookup.lookupCode(sideEffectGrading))
+                  .setDisplay(displaySideEffectGradingLookup.lookupDisplay(sideEffectGrading))
                   .setSystem(fhirProperties.getSystems().getCtcaeGrading()));
         }
 


### PR DESCRIPTION
This declares static fields containing the provided Maps and also removes now obsolete constructors.
The explicit naming of lookup-methods is has been removed, since the class name provides the same information.

More:
- Further more, all classes contain lookup methods that makes an object creation of `*Lookup` classes obsolete.
- It could be a good idea to provide methods like `has(..): boolean` to be able to check if a lookup would succeed instead of simply returning `null`.