### PR TITLE
fix: date conversion w/o Exception and for oBDS 3.x

### DIFF
--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapperTests.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapperTests.java
@@ -47,12 +47,16 @@ class ObdsToFhirMapperTests {
     "31.03.2022,2022-03-31",
     "2019-12-21+02:00,2019-12-21",
     "2000-01-03-01:00,2000-01-03",
-    "1999-12-31+08:00,1999-12-31"
+    "1999-12-31+08:00,1999-12-31",
+    "2024-08-17,2024-08-17",
+    "2024-08-00,2024-08-15",
+    "2024-00-00,2024-07-01"
   })
   void extractDateTimeFromADTDate_withGivenObdsDate_shouldConvertToExpectedFhirDateTime(
       String obdsDate, String expectedFhirDateTimeString) {
     var fhirDate = ObdsToFhirMapper.convertObdsDateToDateTimeType(obdsDate);
 
+    assertThat(fhirDate).isNotNull();
     assertThat(fhirDate.asStringValue()).isEqualTo(expectedFhirDateTimeString);
   }
 
@@ -83,5 +87,11 @@ class ObdsToFhirMapperTests {
             null);
 
     assertThat(prioritised).first().isEqualTo(expectedFirstDeathMeldung);
+  }
+
+  @Test
+  void convertObdsDateToDateTimeTypeShouldNotThrowException() {
+    var fhirDate = ObdsToFhirMapper.convertObdsDateToDateTimeType("some shiny day somewere");
+    assertThat(fhirDate).isNull();
   }
 }


### PR DESCRIPTION
This fix will change convertObdsDateToDateTimeType() in a way that it does not throw a DateTimeException if some nonsense input is given or the input is already in FHIR date string representation.

* oBSD 3.x date string will now be parsed.
* Nonsens input will result in `null` as already be done for empty strings without throwing any exceptions.
* A log message occurs instead of an exception.