### PR TITLE
fix: return timespan of all partial radiations

### DIFF
--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsProcedureMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsProcedureMapper.java
@@ -1,7 +1,6 @@
 package org.miracum.streams.ume.obdstofhir.mapper;
 
 import java.util.*;
-import lombok.val;
 import org.hl7.fhir.r4.model.*;
 import org.miracum.streams.ume.obdstofhir.FhirProperties;
 import org.miracum.streams.ume.obdstofhir.lookup.*;
@@ -514,14 +513,14 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
       return new Tupel<>(null, null);
     }
 
-    val minDates =
+    final var minDates =
         partialRadiations.stream()
             .map(radio -> convertObdsDateToDateTimeType(radio.getST_Beginn_Datum()))
             .filter(Objects::nonNull)
             .map(PrimitiveType::getValue)
             .toList();
 
-    val maxDates =
+    final var maxDates =
         partialRadiations.stream()
             .map(radio -> convertObdsDateToDateTimeType(radio.getST_Ende_Datum()))
             .filter(Objects::nonNull)

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsProcedureMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsProcedureMapper.java
@@ -510,6 +510,10 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
    * @return A tuple with start date and end date of all given partial radiations
    */
   public Tupel<Date, Date> getTimeSpanFromPartialRadiations(List<Bestrahlung> partialRadiations) {
+    if (null == partialRadiations || partialRadiations.isEmpty()) {
+      return new Tupel<>(null, null);
+    }
+
     val minDates =
         partialRadiations.stream()
             .map(radio -> convertObdsDateToDateTimeType(radio.getST_Beginn_Datum()))

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsProcedureMapperTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsProcedureMapperTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
-import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.miracum.streams.ume.obdstofhir.FhirProperties;
@@ -23,13 +22,13 @@ public class ObdsProcedureMapperTest {
 
   @Test
   void shouldGetWholeTimeSpanFromPartialRadiations() {
-    val partialRadiations =
+    final var partialRadiations =
         List.of(
             getTestPartialRadiationForTimespand("01.01.2024", "31.01.2024"),
             getTestPartialRadiationForTimespand("01.03.2024", "30.04.2024"),
             getTestPartialRadiationForTimespand("10.05.2024", "31.05.2024"));
 
-    val actual = this.mapper.getTimeSpanFromPartialRadiations(partialRadiations);
+    final var actual = this.mapper.getTimeSpanFromPartialRadiations(partialRadiations);
 
     assertThat(actual)
         .isEqualTo(

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsProcedureMapperTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsProcedureMapperTest.java
@@ -1,0 +1,48 @@
+package org.miracum.streams.ume.obdstofhir.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.miracum.streams.ume.obdstofhir.FhirProperties;
+import org.miracum.streams.ume.obdstofhir.model.ADT_GEKID.Menge_Patient.Patient.Menge_Meldung.Meldung.Menge_ST.ST.Menge_Bestrahlung.Bestrahlung;
+import org.miracum.streams.ume.obdstofhir.model.Tupel;
+
+public class ObdsProcedureMapperTest {
+
+  private ObdsProcedureMapper mapper;
+
+  @BeforeEach
+  void setup() {
+    this.mapper = new ObdsProcedureMapper(new FhirProperties());
+  }
+
+  @Test
+  void shouldGetWholeTimeSpanFromPartialRadiations() {
+    val partialRadiations =
+        List.of(
+            getTestPartialRadiationForTimespand("01.01.2024", "31.01.2024"),
+            getTestPartialRadiationForTimespand("01.03.2024", "30.04.2024"),
+            getTestPartialRadiationForTimespand("10.05.2024", "31.05.2024"));
+
+    val actual = this.mapper.getTimeSpanFromPartialRadiations(partialRadiations);
+
+    assertThat(actual)
+        .isEqualTo(
+            Tupel.builder()
+                .first(Date.from(Instant.parse("2024-01-01T00:00:00Z")))
+                .second(Date.from(Instant.parse("2024-05-31T00:00:00Z")))
+                .build());
+  }
+
+  private static Bestrahlung getTestPartialRadiationForTimespand(String start, String end) {
+    Bestrahlung bestrahlung = new Bestrahlung();
+    bestrahlung.setST_Beginn_Datum(start);
+    bestrahlung.setST_Ende_Datum(end);
+    return bestrahlung;
+  }
+}


### PR DESCRIPTION
This will fix #79 und returns the timespan of all partial radiations as suggested as the intention of this method.