### PR TITLE
feat: support capture groups in Pat-ID convert

### DIFF
--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapper.java
@@ -76,7 +76,15 @@ public abstract class ObdsToFhirMapper {
   protected static String convertId(String id) {
     Matcher matcher = ObdsToFhirMapper.localPatientIdPattern.matcher(id);
     if (matcher.find()) {
-      return matcher.group();
+      if (matcher.groupCount() == 0) {
+        return matcher.group();
+      }
+      var resultBuilder = new StringBuilder();
+      for (int i = 1; i <= matcher.groupCount(); i++) {
+        var x = matcher.group(i);
+        resultBuilder.append(x);
+      }
+      return resultBuilder.toString();
     } else {
       log.warn("Identifier to convert does not match pattern: {}", matcher.pattern().toString());
       return id;

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirIntegrationTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirIntegrationTest.java
@@ -2,6 +2,7 @@ package org.miracum.streams.ume.obdstofhir.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,7 +20,30 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @MockBean(FhirProperties.class)
 public class ObdsToFhirIntegrationTest {
 
-  @Autowired ObdsTestMapper mapper;
+  ObdsTestMapper mapper;
+
+  @BeforeEach
+  void setUp(@Autowired ObdsTestMapper mapper) {
+    this.mapper = mapper;
+  }
+
+  @Nested
+  @TestPropertySource(properties = {""})
+  class UseDefaultPatternWithoutConfig {
+
+    @ParameterizedTest
+    @CsvSource({
+      "12345,12345",
+      "123456789,123456789",
+      "1234567890,123456789", // Max 9 digits, remove last digit '0'
+      "1234567891,123456789", // Max 9 digits, remove last digit '1'
+      "0000012345,0000012345", // Not mathching pattern - keep as is
+    })
+    void applyDefaultPattern(String input, String output) {
+      var actual = ObdsToFhirMapper.convertId(input);
+      assertThat(actual).isEqualTo(output);
+    }
+  }
 
   @Nested
   @TestPropertySource(properties = {"app.patient-id-pattern=\\\\w*"})
@@ -40,17 +64,34 @@ public class ObdsToFhirIntegrationTest {
   }
 
   @Nested
-  class UseDefaultPatternWithoutConfig {
+  @TestPropertySource(properties = {"app.patient-id-pattern=G([0-9]{8})"})
+  class UsePatternWithCaptureGroups {
 
     @ParameterizedTest
     @CsvSource({
-      "12345,12345",
-      "123456789,123456789",
-      "1234567890,123456789", // Max 9 digits, remove last digit '0'
-      "1234567891,123456789", // Max 9 digits, remove last digit '1'
-      "0000012345,0000012345", // Not mathching pattern - keep as is
+      "12345,12345", // not matching, return as is ...
+      // else return first complete group of 8 numbers found in input after "G"
+      "G1234567890,12345678",
+      "G12345678,12345678",
     })
-    void applyDefaultPattern(String input, String output) {
+    void applyPatientIdPattern(String input, String output) {
+      var actual = ObdsToFhirMapper.convertId(input);
+      assertThat(actual).isEqualTo(output);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"app.patient-id-pattern=G/([0-9]{4})-([0-9]{4})"})
+  class UsePatternWithMultipleCaptureGroups {
+
+    @ParameterizedTest
+    @CsvSource({
+      "12345,12345", // not matching, return as is ...
+      // else return complete groups of 4 numbers found in input after "G/" and seperated by "-"
+      "G/1234-56789,12345678",
+      "G/1234-5678,12345678",
+    })
+    void applyPatientIdPattern(String input, String output) {
       var actual = ObdsToFhirMapper.convertId(input);
       assertThat(actual).isEqualTo(output);
     }


### PR DESCRIPTION
This will convert Pat-ID by using capture groups:
* Pattern `G([0-9]{8})` will convert `G12345678` to `12345678`
* Pattern `G([0-9]{8})` will convert `G123456789` to `12345678`
* Pattern `G/([0-9]{4})-([0-9]{4})` will convert `G/1234-5678` to `12345678`

If pattern does not match, this will return Pat-ID as is:
* Pattern `([0-9]{8})` will not convert `G12345678` and return it without change.

More examples in UnitTests.

Without capture groups in RegExp, `convertId(String)` will keep its old behaviour.