### PR TITLE
feat: add code generation for oBDS v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ package-lock.json
 tests/k8s/**/charts
 
 node_modules/
+
+# generated code
+src/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+	xsd2java
 }
 
 repositories {
@@ -25,6 +26,15 @@ repositories {
 ext {
 	set('springCloudVersion', "2023.0.3")
 	set('hapiVersion', "7.4.0")
+	jaxbTargetDir = file("src/generated/java")
+}
+
+sourceSets {
+	main {
+		java {
+			srcDirs jaxbTargetDir
+		}
+	}
 }
 
 dependencies {
@@ -44,7 +54,11 @@ dependencies {
 	// Jackson v3 supports Optional out-of-the-box but isn't yet provided by Spring Boot by default
 	// <https://github.com/FasterXML/jackson-modules-java8>
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
+	implementation 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations'
 
+	// JAXB code generation
+	xsd2java "com.sun.xml.bind:jaxb-xjc:4.0.5"
+	xsd2java "com.sun.xml.bind:jaxb-impl:4.0.5"
 
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
@@ -88,3 +102,22 @@ jacocoTestReport {
 jar {
 	enabled = false
 }
+
+tasks.register('xsd2java') {
+
+	doLast {
+		jaxbTargetDir.mkdirs()
+
+		ant.taskdef(name: 'xjc', classname: 'com.sun.tools.xjc.XJCTask', classpath: configurations.xsd2java.asPath)
+		ant.jaxbTargetDir = jaxbTargetDir
+
+
+		ant.xjc(
+				destdir: '${jaxbTargetDir}',
+				package: 'de.basisdatensatz.obds3',
+				schema: 'src/main/resources/schema/oBDS_v3.0.2.xsd'
+		)
+
+	}
+}
+compileJava.dependsOn xsd2java

--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ tasks.register('xsd2java') {
 
 		ant.xjc(
 				destdir: '${jaxbTargetDir}',
-				package: 'de.basisdatensatz.obds3',
+				package: 'de.basisdatensatz.obds.v3',
 				schema: 'src/main/resources/schema/oBDS_v3.0.2.xsd'
 		)
 

--- a/src/main/resources/schema/oBDS_v3.0.2.xsd
+++ b/src/main/resources/schema/oBDS_v3.0.2.xsd
@@ -1,0 +1,5804 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns="http://www.basisdatensatz.de/oBDS/XML" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.basisdatensatz.de/oBDS/XML" targetNamespace="http://www.basisdatensatz.de/oBDS/XML" elementFormDefault="qualified" attributeFormDefault="unqualified" version="3.0.2 vom 17.10.2023">
+    <xs:element name="oBDS">
+        <xs:annotation>
+            <xs:documentation>Root element</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="Absender" type="Absender_Typ"/>
+                <xs:element name="Meldedatum" type="Datum_Tag_genau_Typ"/>
+                <xs:element name="Menge_Patient">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="Patient" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="Patienten_Stammdaten" type="Patienten_Stammdaten_Melder_Typ"/>
+                                        <xs:element name="Menge_Meldung">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element name="Meldung" maxOccurs="unbounded">
+                                                        <xs:complexType>
+                                                            <xs:sequence>
+                                                                <xs:element name="Meldebegruendung" type="Meldebegruendung_Typ"/>
+                                                                <xs:element name="Einwilligung_nicht_meldepflichtig" type="JN_Typ" minOccurs="0">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>Einwilligung für nicht meldepflichtige Meldeanlässe vorhanden (derzeit nur Niedersachsen)</xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:element>
+                                                                <xs:element name="Zertifizierung" type="Zertifizierung_Typ" minOccurs="0"/>
+                                                                <xs:element name="Eigene_Leistung" type="JNU_Typ">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>
+                                                                            Aus Gründen unter anderem der Qualitätssicherung ist eine explizite Angabe von Ja oder Nein erforderlich.
+                                                                            Die Ausprägung "unbekannt" darf nur verwendet werden, wenn es sich um historische Sätze handelt, für die die Situation nicht zu klären ist.
+                                                                            Für aktuelle Sätze muss diese Information bekannt und in den Systemen hinterlegbar sein.
+                                                                        </xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:element>
+                                                                <xs:element name="Tumorzuordnung" type="Tumorzuordnung_Typ"/>
+                                                                <xs:choice>
+                                                                    <xs:element name="Diagnose" type="Diagnose_Typ"/>
+                                                                    <xs:element name="Pathologie" type="Pathologie_Typ"/>
+                                                                    <xs:element name="OP" type="OP_Typ"/>
+                                                                    <xs:element name="ST" type="ST_Typ"/>
+                                                                    <xs:element name="SYST" type="SYST_Typ"/>
+                                                                    <xs:element name="Verlauf" type="Verlauf_Typ"/>
+                                                                    <xs:element name="Tod" type="Tod_Typ"/>
+                                                                    <xs:element name="Tumorkonferenz" type="Tumorkonferenz_Typ"/>
+                                                                </xs:choice>
+                                                                <xs:element name="Menge_Zusatzitem" type="Menge_Zusatzitem_Typ" minOccurs="0"/>
+                                                                <xs:element name="Anmerkung" type="FreitextAnmerkung_Typ" minOccurs="0"/>
+                                                            </xs:sequence>
+                                                            <xs:attribute name="Meldung_ID" type="FreitextID_Typ" use="required"/>
+                                                            <xs:attribute name="Melder_ID" type="FreitextID_Typ" use="required"/>
+                                                        </xs:complexType>
+                                                    </xs:element>
+                                                </xs:sequence>
+                                            </xs:complexType>
+                                        </xs:element>
+                                        <xs:element name="Anmerkung" type="FreitextAnmerkung_Typ" minOccurs="0"/>
+                                    </xs:sequence>
+                                    <xs:attribute name="Patient_ID" type="FreitextID_Typ" use="required"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Menge_Melder">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="Melder" type="Melder_Typ" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Schema_Version" use="required">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="3.0.0">
+                            <xs:annotation>
+                                <xs:documentation>Erste Version beruhend auf Basisdatensatz 2021</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="3.0.1">
+                            <xs:annotation>
+                                <xs:documentation>Patch: Fehler im Modul DKKR behoben (GPOH_Therapiestudienpatient: Auswahl 2=nein statt 1=ja), Beschreibung im Nuklide_Typ korrigiert (Ir-192), Referenzprüfung Melder/ID auf Meldung/Melder_ID korrigiert (war vertauscht)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="3.0.2">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    - Erweiterung der zulässigen ICD-10-Versionen über das Jahr 2023 hinaus
+                                    - Ergänzung Diagnosesicherung 7.1-3 und 8 (§65c 2023/63/c1) </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+        </xs:complexType>
+        <xs:unique name="ID_Patient">
+            <xs:selector xpath="tns:Menge_Patient/tns:Patient"/>
+            <xs:field xpath="@Patient_ID"/>
+        </xs:unique>
+        <xs:unique name="ID_Meldung">
+            <xs:selector xpath="tns:Menge_Patient/tns:Patient/tns:Menge_Meldung/tns:Meldung"/>
+            <xs:field xpath="@Meldung_ID"/>
+        </xs:unique>
+        <xs:unique name="ID_Melder">
+            <xs:selector xpath="tns:Menge_Melder/tns:Melder"/>
+            <xs:field xpath="@ID"/>
+        </xs:unique>
+        <xs:keyref name="Ref_Melder" refer="ID_Melder">
+            <xs:selector xpath="tns:Menge_Patient/tns:Patient/tns:Menge_Meldung/tns:Meldung"/>
+            <xs:field xpath="@Melder_ID"/>
+        </xs:keyref>
+    </xs:element>
+    <xs:annotation>
+        <xs:documentation>Automatisiert erstellt am 16.11.2018 um 6:21 Uhr aus der Spezifikation file:/C:/Users/rico/Documents/arbeit/KoSIT/string.latin/06_SVN/src/din%20spec%2091379/din-spec.xml.</xs:documentation>
+    </xs:annotation>
+    <xs:simpleType name="datatypeAtrimmed">
+        <xs:annotation>
+            <xs:documentation>Ergänzung: kein Whitespace am Anfang oder Ende. Der Datentyp A gibt wieder, welche Schriftzeichen in hoheitlichen Dokumenten für Namen natürlicher Personen verwendet werden.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="(('|[,-\.]|[A-Z]|[`-z]|~|¨|´|·|[À-Ö]|[Ø-ö]|[ø-ž]|[Ƈ-ƈ]|Ə|Ɨ|[Ơ-ơ]|[Ư-ư]|Ʒ|[Ǎ-ǜ]|[Ǟ-ǟ]|[Ǣ-ǰ]|[Ǵ-ǵ]|[Ǹ-ǿ]|[Ȓ-ȓ]|[Ș-ț]|[Ȟ-ȟ]|[ȧ-ȳ]|ə|ɨ|ʒ|[ʹ-ʺ]|[ʾ-ʿ]|ˈ|ˌ|[Ḃ-ḃ]|[Ḇ-ḇ]|[Ḋ-ḑ]|[Ḝ-ḫ]|[ḯ-ḷ]|[Ḻ-ḻ]|[Ṁ-ṉ]|[Ṓ-ṛ]|[Ṟ-ṣ]|[Ṫ-ṯ]|[Ẁ-ẇ]|[Ẍ-ẗ]|ẞ|[Ạ-ỹ]|’|‡|A̋|C(̀|̄|̆|̈|̕|̣|̦|̨̆)|D̂|F(̀|̄)|G̀|H(̄|̦|̱)|J(́|̌)|K(̀|̂|̄|̇|̕|̛|̦|͟H|͟h)|L(̂|̥|̥̄|̦)|M(̀|̂|̆|̐)|N(̂|̄|̆|̦)|P(̀|̄|̕|̣)|R(̆|̥|̥̄)|S(̀|̄|̛̄|̱)|T(̀|̄|̈|̕|̛)|U̇|Z(̀|̄|̆|̈|̧)|a̋|c(̀|̄|̆|̈|̕|̣|̦|̨̆)|d̂|f(̀|̄)|g̀|h(̄|̦)|j́|k(̀|̂|̄|̇|̕|̛|̦|͟h)|l(̂|̥|̥̄|̦)|m(̀|̂|̆|̐)|n(̂|̄|̆|̦)|p(̀|̄|̕|̣)|r(̆|̥|̥̄)|s(̀|̄|̛̄|̱)|t(̀|̄|̕|̛)|u̇|z(̀|̄|̆|̈|̧)|Ç̆|Û̄|ç̆|û̄|ÿ́|Č(̕|̣)|č(̕|̣)|Ī́|ī́|Ž(̦|̧)|ž(̦|̧)|Ḳ̄|ḳ̄|Ṣ̄|ṣ̄|Ṭ̄|ṭ̄|Ạ̈|ạ̈|Ọ̈|ọ̈|Ụ(̄|̈)|ụ(̄|̈))( |'|[,-\.]|[A-Z]|[`-z]|~|¨|´|·|[À-Ö]|[Ø-ö]|[ø-ž]|[Ƈ-ƈ]|Ə|Ɨ|[Ơ-ơ]|[Ư-ư]|Ʒ|[Ǎ-ǜ]|[Ǟ-ǟ]|[Ǣ-ǰ]|[Ǵ-ǵ]|[Ǹ-ǿ]|[Ȓ-ȓ]|[Ș-ț]|[Ȟ-ȟ]|[ȧ-ȳ]|ə|ɨ|ʒ|[ʹ-ʺ]|[ʾ-ʿ]|ˈ|ˌ|[Ḃ-ḃ]|[Ḇ-ḇ]|[Ḋ-ḑ]|[Ḝ-ḫ]|[ḯ-ḷ]|[Ḻ-ḻ]|[Ṁ-ṉ]|[Ṓ-ṛ]|[Ṟ-ṣ]|[Ṫ-ṯ]|[Ẁ-ẇ]|[Ẍ-ẗ]|ẞ|[Ạ-ỹ]|’|‡|A̋|C(̀|̄|̆|̈|̕|̣|̦|̨̆)|D̂|F(̀|̄)|G̀|H(̄|̦|̱)|J(́|̌)|K(̀|̂|̄|̇|̕|̛|̦|͟H|͟h)|L(̂|̥|̥̄|̦)|M(̀|̂|̆|̐)|N(̂|̄|̆|̦)|P(̀|̄|̕|̣)|R(̆|̥|̥̄)|S(̀|̄|̛̄|̱)|T(̀|̄|̈|̕|̛)|U̇|Z(̀|̄|̆|̈|̧)|a̋|c(̀|̄|̆|̈|̕|̣|̦|̨̆)|d̂|f(̀|̄)|g̀|h(̄|̦)|j́|k(̀|̂|̄|̇|̕|̛|̦|͟h)|l(̂|̥|̥̄|̦)|m(̀|̂|̆|̐)|n(̂|̄|̆|̦)|p(̀|̄|̕|̣)|r(̆|̥|̥̄)|s(̀|̄|̛̄|̱)|t(̀|̄|̕|̛)|u̇|z(̀|̄|̆|̈|̧)|Ç̆|Û̄|ç̆|û̄|ÿ́|Č(̕|̣)|č(̕|̣)|Ī́|ī́|Ž(̦|̧)|ž(̦|̧)|Ḳ̄|ḳ̄|Ṣ̄|ṣ̄|Ṭ̄|ṭ̄|Ạ̈|ạ̈|Ọ̈|ọ̈|Ụ(̄|̈)|ụ(̄|̈))*('|[,-\.]|[A-Z]|[`-z]|~|¨|´|·|[À-Ö]|[Ø-ö]|[ø-ž]|[Ƈ-ƈ]|Ə|Ɨ|[Ơ-ơ]|[Ư-ư]|Ʒ|[Ǎ-ǜ]|[Ǟ-ǟ]|[Ǣ-ǰ]|[Ǵ-ǵ]|[Ǹ-ǿ]|[Ȓ-ȓ]|[Ș-ț]|[Ȟ-ȟ]|[ȧ-ȳ]|ə|ɨ|ʒ|[ʹ-ʺ]|[ʾ-ʿ]|ˈ|ˌ|[Ḃ-ḃ]|[Ḇ-ḇ]|[Ḋ-ḑ]|[Ḝ-ḫ]|[ḯ-ḷ]|[Ḻ-ḻ]|[Ṁ-ṉ]|[Ṓ-ṛ]|[Ṟ-ṣ]|[Ṫ-ṯ]|[Ẁ-ẇ]|[Ẍ-ẗ]|ẞ|[Ạ-ỹ]|’|‡|A̋|C(̀|̄|̆|̈|̕|̣|̦|̨̆)|D̂|F(̀|̄)|G̀|H(̄|̦|̱)|J(́|̌)|K(̀|̂|̄|̇|̕|̛|̦|͟H|͟h)|L(̂|̥|̥̄|̦)|M(̀|̂|̆|̐)|N(̂|̄|̆|̦)|P(̀|̄|̕|̣)|R(̆|̥|̥̄)|S(̀|̄|̛̄|̱)|T(̀|̄|̈|̕|̛)|U̇|Z(̀|̄|̆|̈|̧)|a̋|c(̀|̄|̆|̈|̕|̣|̦|̨̆)|d̂|f(̀|̄)|g̀|h(̄|̦)|j́|k(̀|̂|̄|̇|̕|̛|̦|͟h)|l(̂|̥|̥̄|̦)|m(̀|̂|̆|̐)|n(̂|̄|̆|̦)|p(̀|̄|̕|̣)|r(̆|̥|̥̄)|s(̀|̄|̛̄|̱)|t(̀|̄|̕|̛)|u̇|z(̀|̄|̆|̈|̧)|Ç̆|Û̄|ç̆|û̄|ÿ́|Č(̕|̣)|č(̕|̣)|Ī́|ī́|Ž(̦|̧)|ž(̦|̧)|Ḳ̄|ḳ̄|Ṣ̄|ṣ̄|Ṭ̄|ṭ̄|Ạ̈|ạ̈|Ọ̈|ọ̈|Ụ(̄|̈)|ụ(̄|̈)))|('|[,-\.]|[A-Z]|[`-z]|~|¨|´|·|[À-Ö]|[Ø-ö]|[ø-ž]|[Ƈ-ƈ]|Ə|Ɨ|[Ơ-ơ]|[Ư-ư]|Ʒ|[Ǎ-ǜ]|[Ǟ-ǟ]|[Ǣ-ǰ]|[Ǵ-ǵ]|[Ǹ-ǿ]|[Ȓ-ȓ]|[Ș-ț]|[Ȟ-ȟ]|[ȧ-ȳ]|ə|ɨ|ʒ|[ʹ-ʺ]|[ʾ-ʿ]|ˈ|ˌ|[Ḃ-ḃ]|[Ḇ-ḇ]|[Ḋ-ḑ]|[Ḝ-ḫ]|[ḯ-ḷ]|[Ḻ-ḻ]|[Ṁ-ṉ]|[Ṓ-ṛ]|[Ṟ-ṣ]|[Ṫ-ṯ]|[Ẁ-ẇ]|[Ẍ-ẗ]|ẞ|[Ạ-ỹ]|’|‡|A̋|C(̀|̄|̆|̈|̕|̣|̦|̨̆)|D̂|F(̀|̄)|G̀|H(̄|̦|̱)|J(́|̌)|K(̀|̂|̄|̇|̕|̛|̦|͟H|͟h)|L(̂|̥|̥̄|̦)|M(̀|̂|̆|̐)|N(̂|̄|̆|̦)|P(̀|̄|̕|̣)|R(̆|̥|̥̄)|S(̀|̄|̛̄|̱)|T(̀|̄|̈|̕|̛)|U̇|Z(̀|̄|̆|̈|̧)|a̋|c(̀|̄|̆|̈|̕|̣|̦|̨̆)|d̂|f(̀|̄)|g̀|h(̄|̦)|j́|k(̀|̂|̄|̇|̕|̛|̦|͟h)|l(̂|̥|̥̄|̦)|m(̀|̂|̆|̐)|n(̂|̄|̆|̦)|p(̀|̄|̕|̣)|r(̆|̥|̥̄)|s(̀|̄|̛̄|̱)|t(̀|̄|̕|̛)|u̇|z(̀|̄|̆|̈|̧)|Ç̆|Û̄|ç̆|û̄|ÿ́|Č(̕|̣)|č(̕|̣)|Ī́|ī́|Ž(̦|̧)|ž(̦|̧)|Ḳ̄|ḳ̄|Ṣ̄|ṣ̄|Ṭ̄|ṭ̄|Ạ̈|ạ̈|Ọ̈|ọ̈|Ụ(̄|̈)|ụ(̄|̈)){0,1}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="datatypeBtrimmed">
+        <xs:annotation>
+            <xs:documentation>Ergänzung: kein Whitespace am Anfang oder Ende. Der Datentyp B wurde vor allem für sonstige Namen, wie z. B. Ortsnamen und Straßennamen mit Hausnummer, entworfen.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="(([!-~]|[¡-£]|¥|[§-¬]|[®-·]|[¹-»]|[¿-ž]|[Ƈ-ƈ]|Ə|Ɨ|[Ơ-ơ]|[Ư-ư]|Ʒ|[Ǎ-ǜ]|[Ǟ-ǟ]|[Ǣ-ǰ]|[Ǵ-ǵ]|[Ǹ-ǿ]|[Ȓ-ȓ]|[Ș-ț]|[Ȟ-ȟ]|[ȧ-ȳ]|ə|ɨ|ʒ|[ʹ-ʺ]|[ʾ-ʿ]|ˈ|ˌ|[Ḃ-ḃ]|[Ḇ-ḇ]|[Ḋ-ḑ]|[Ḝ-ḫ]|[ḯ-ḷ]|[Ḻ-ḻ]|[Ṁ-ṉ]|[Ṓ-ṛ]|[Ṟ-ṣ]|[Ṫ-ṯ]|[Ẁ-ẇ]|[Ẍ-ẗ]|ẞ|[Ạ-ỹ]|’|‡|€|A̋|C(̀|̄|̆|̈|̕|̣|̦|̨̆)|D̂|F(̀|̄)|G̀|H(̄|̦|̱)|J(́|̌)|K(̀|̂|̄|̇|̕|̛|̦|͟H|͟h)|L(̂|̥|̥̄|̦)|M(̀|̂|̆|̐)|N(̂|̄|̆|̦)|P(̀|̄|̕|̣)|R(̆|̥|̥̄)|S(̀|̄|̛̄|̱)|T(̀|̄|̈|̕|̛)|U̇|Z(̀|̄|̆|̈|̧)|a̋|c(̀|̄|̆|̈|̕|̣|̦|̨̆)|d̂|f(̀|̄)|g̀|h(̄|̦)|j́|k(̀|̂|̄|̇|̕|̛|̦|͟h)|l(̂|̥|̥̄|̦)|m(̀|̂|̆|̐)|n(̂|̄|̆|̦)|p(̀|̄|̕|̣)|r(̆|̥|̥̄)|s(̀|̄|̛̄|̱)|t(̀|̄|̕|̛)|u̇|z(̀|̄|̆|̈|̧)|Ç̆|Û̄|ç̆|û̄|ÿ́|Č(̕|̣)|č(̕|̣)|Ī́|ī́|Ž(̦|̧)|ž(̦|̧)|Ḳ̄|ḳ̄|Ṣ̄|ṣ̄|Ṭ̄|ṭ̄|Ạ̈|ạ̈|Ọ̈|ọ̈|Ụ(̄|̈)|ụ(̄|̈))([ -~]|[¡-£]|¥|[§-¬]|[®-·]|[¹-»]|[¿-ž]|[Ƈ-ƈ]|Ə|Ɨ|[Ơ-ơ]|[Ư-ư]|Ʒ|[Ǎ-ǜ]|[Ǟ-ǟ]|[Ǣ-ǰ]|[Ǵ-ǵ]|[Ǹ-ǿ]|[Ȓ-ȓ]|[Ș-ț]|[Ȟ-ȟ]|[ȧ-ȳ]|ə|ɨ|ʒ|[ʹ-ʺ]|[ʾ-ʿ]|ˈ|ˌ|[Ḃ-ḃ]|[Ḇ-ḇ]|[Ḋ-ḑ]|[Ḝ-ḫ]|[ḯ-ḷ]|[Ḻ-ḻ]|[Ṁ-ṉ]|[Ṓ-ṛ]|[Ṟ-ṣ]|[Ṫ-ṯ]|[Ẁ-ẇ]|[Ẍ-ẗ]|ẞ|[Ạ-ỹ]|’|‡|€|A̋|C(̀|̄|̆|̈|̕|̣|̦|̨̆)|D̂|F(̀|̄)|G̀|H(̄|̦|̱)|J(́|̌)|K(̀|̂|̄|̇|̕|̛|̦|͟H|͟h)|L(̂|̥|̥̄|̦)|M(̀|̂|̆|̐)|N(̂|̄|̆|̦)|P(̀|̄|̕|̣)|R(̆|̥|̥̄)|S(̀|̄|̛̄|̱)|T(̀|̄|̈|̕|̛)|U̇|Z(̀|̄|̆|̈|̧)|a̋|c(̀|̄|̆|̈|̕|̣|̦|̨̆)|d̂|f(̀|̄)|g̀|h(̄|̦)|j́|k(̀|̂|̄|̇|̕|̛|̦|͟h)|l(̂|̥|̥̄|̦)|m(̀|̂|̆|̐)|n(̂|̄|̆|̦)|p(̀|̄|̕|̣)|r(̆|̥|̥̄)|s(̀|̄|̛̄|̱)|t(̀|̄|̕|̛)|u̇|z(̀|̄|̆|̈|̧)|Ç̆|Û̄|ç̆|û̄|ÿ́|Č(̕|̣)|č(̕|̣)|Ī́|ī́|Ž(̦|̧)|ž(̦|̧)|Ḳ̄|ḳ̄|Ṣ̄|ṣ̄|Ṭ̄|ṭ̄|Ạ̈|ạ̈|Ọ̈|ọ̈|Ụ(̄|̈)|ụ(̄|̈))*([!-~]|[¡-£]|¥|[§-¬]|[®-·]|[¹-»]|[¿-ž]|[Ƈ-ƈ]|Ə|Ɨ|[Ơ-ơ]|[Ư-ư]|Ʒ|[Ǎ-ǜ]|[Ǟ-ǟ]|[Ǣ-ǰ]|[Ǵ-ǵ]|[Ǹ-ǿ]|[Ȓ-ȓ]|[Ș-ț]|[Ȟ-ȟ]|[ȧ-ȳ]|ə|ɨ|ʒ|[ʹ-ʺ]|[ʾ-ʿ]|ˈ|ˌ|[Ḃ-ḃ]|[Ḇ-ḇ]|[Ḋ-ḑ]|[Ḝ-ḫ]|[ḯ-ḷ]|[Ḻ-ḻ]|[Ṁ-ṉ]|[Ṓ-ṛ]|[Ṟ-ṣ]|[Ṫ-ṯ]|[Ẁ-ẇ]|[Ẍ-ẗ]|ẞ|[Ạ-ỹ]|’|‡|€|A̋|C(̀|̄|̆|̈|̕|̣|̦|̨̆)|D̂|F(̀|̄)|G̀|H(̄|̦|̱)|J(́|̌)|K(̀|̂|̄|̇|̕|̛|̦|͟H|͟h)|L(̂|̥|̥̄|̦)|M(̀|̂|̆|̐)|N(̂|̄|̆|̦)|P(̀|̄|̕|̣)|R(̆|̥|̥̄)|S(̀|̄|̛̄|̱)|T(̀|̄|̈|̕|̛)|U̇|Z(̀|̄|̆|̈|̧)|a̋|c(̀|̄|̆|̈|̕|̣|̦|̨̆)|d̂|f(̀|̄)|g̀|h(̄|̦)|j́|k(̀|̂|̄|̇|̕|̛|̦|͟h)|l(̂|̥|̥̄|̦)|m(̀|̂|̆|̐)|n(̂|̄|̆|̦)|p(̀|̄|̕|̣)|r(̆|̥|̥̄)|s(̀|̄|̛̄|̱)|t(̀|̄|̕|̛)|u̇|z(̀|̄|̆|̈|̧)|Ç̆|Û̄|ç̆|û̄|ÿ́|Č(̕|̣)|č(̕|̣)|Ī́|ī́|Ž(̦|̧)|ž(̦|̧)|Ḳ̄|ḳ̄|Ṣ̄|ṣ̄|Ṭ̄|ṭ̄|Ạ̈|ạ̈|Ọ̈|ọ̈|Ụ(̄|̈)|ụ(̄|̈)))|([!-~]|[¡-£]|¥|[§-¬]|[®-·]|[¹-»]|[¿-ž]|[Ƈ-ƈ]|Ə|Ɨ|[Ơ-ơ]|[Ư-ư]|Ʒ|[Ǎ-ǜ]|[Ǟ-ǟ]|[Ǣ-ǰ]|[Ǵ-ǵ]|[Ǹ-ǿ]|[Ȓ-ȓ]|[Ș-ț]|[Ȟ-ȟ]|[ȧ-ȳ]|ə|ɨ|ʒ|[ʹ-ʺ]|[ʾ-ʿ]|ˈ|ˌ|[Ḃ-ḃ]|[Ḇ-ḇ]|[Ḋ-ḑ]|[Ḝ-ḫ]|[ḯ-ḷ]|[Ḻ-ḻ]|[Ṁ-ṉ]|[Ṓ-ṛ]|[Ṟ-ṣ]|[Ṫ-ṯ]|[Ẁ-ẇ]|[Ẍ-ẗ]|ẞ|[Ạ-ỹ]|’|‡|€|A̋|C(̀|̄|̆|̈|̕|̣|̦|̨̆)|D̂|F(̀|̄)|G̀|H(̄|̦|̱)|J(́|̌)|K(̀|̂|̄|̇|̕|̛|̦|͟H|͟h)|L(̂|̥|̥̄|̦)|M(̀|̂|̆|̐)|N(̂|̄|̆|̦)|P(̀|̄|̕|̣)|R(̆|̥|̥̄)|S(̀|̄|̛̄|̱)|T(̀|̄|̈|̕|̛)|U̇|Z(̀|̄|̆|̈|̧)|a̋|c(̀|̄|̆|̈|̕|̣|̦|̨̆)|d̂|f(̀|̄)|g̀|h(̄|̦)|j́|k(̀|̂|̄|̇|̕|̛|̦|͟h)|l(̂|̥|̥̄|̦)|m(̀|̂|̆|̐)|n(̂|̄|̆|̦)|p(̀|̄|̕|̣)|r(̆|̥|̥̄)|s(̀|̄|̛̄|̱)|t(̀|̄|̕|̛)|u̇|z(̀|̄|̆|̈|̧)|Ç̆|Û̄|ç̆|û̄|ÿ́|Č(̕|̣)|č(̕|̣)|Ī́|ī́|Ž(̦|̧)|ž(̦|̧)|Ḳ̄|ḳ̄|Ṣ̄|ṣ̄|Ṭ̄|ṭ̄|Ạ̈|ạ̈|Ọ̈|ọ̈|Ụ(̄|̈)|ụ(̄|̈)){0,1}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="datatypeC">
+        <xs:annotation>
+            <xs:documentation>Der Datentyp C wurde für alle normativen Schriftzeichen der DIN SPEC entworfen. Er ist somit die technische Umsetzung der Schnittstellenvereinbarung Alle nach DIN SPEC 91379 normativen Schriftzeichen. Texte mit griechischen oder kyrillischen Buchstaben oder mit erweiterten (nicht-normativen) Nicht-Buchstaben sind unzulässig. </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="([\s]|[ -~]|[ -¬]|[®-ž]|[Ƈ-ƈ]|Ə|Ɨ|[Ơ-ơ]|[Ư-ư]|Ʒ|[Ǎ-ǜ]|[Ǟ-ǟ]|[Ǣ-ǰ]|[Ǵ-ǵ]|[Ǹ-ǿ]|[Ȓ-ȓ]|[Ș-ț]|[Ȟ-ȟ]|[ȧ-ȳ]|ə|ɨ|ʒ|[ʹ-ʺ]|[ʾ-ʿ]|ˈ|ˌ|[Ḃ-ḃ]|[Ḇ-ḇ]|[Ḋ-ḑ]|[Ḝ-ḫ]|[ḯ-ḷ]|[Ḻ-ḻ]|[Ṁ-ṉ]|[Ṓ-ṛ]|[Ṟ-ṣ]|[Ṫ-ṯ]|[Ẁ-ẇ]|[Ẍ-ẗ]|ẞ|[Ạ-ỹ]|’|‡|€|A̋|C(̀|̄|̆|̈|̕|̣|̦|̨̆)|D̂|F(̀|̄)|G̀|H(̄|̦|̱)|J(́|̌)|K(̀|̂|̄|̇|̕|̛|̦|͟H|͟h)|L(̂|̥|̥̄|̦)|M(̀|̂|̆|̐)|N(̂|̄|̆|̦)|P(̀|̄|̕|̣)|R(̆|̥|̥̄)|S(̀|̄|̛̄|̱)|T(̀|̄|̈|̕|̛)|U̇|Z(̀|̄|̆|̈|̧)|a̋|c(̀|̄|̆|̈|̕|̣|̦|̨̆)|d̂|f(̀|̄)|g̀|h(̄|̦)|j́|k(̀|̂|̄|̇|̕|̛|̦|͟h)|l(̂|̥|̥̄|̦)|m(̀|̂|̆|̐)|n(̂|̄|̆|̦)|p(̀|̄|̕|̣)|r(̆|̥|̥̄)|s(̀|̄|̛̄|̱)|t(̀|̄|̕|̛)|u̇|z(̀|̄|̆|̈|̧)|Ç̆|Û̄|ç̆|û̄|ÿ́|Č(̕|̣)|č(̕|̣)|Ī́|ī́|Ž(̦|̧)|ž(̦|̧)|Ḳ̄|ḳ̄|Ṣ̄|ṣ̄|Ṭ̄|ṭ̄|Ạ̈|ạ̈|Ọ̈|ọ̈|Ụ(̄|̈)|ụ(̄|̈))*"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="datatypeCtrimmed">
+        <xs:annotation>
+            <xs:documentation>Ergänzung: kein Whitespace am Anfang oder Ende.  Der Datentyp C wurde für alle normativen Schriftzeichen der DIN SPEC entworfen. Er ist somit die technische Umsetzung der Schnittstellenvereinbarung Alle nach DIN SPEC 91379 normativen Schriftzeichen. Texte mit griechischen oder kyrillischen Buchstaben oder mit erweiterten (nicht-normativen) Nicht-Buchstaben sind unzulässig. </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="(([!-~]|[ -¬]|[®-ž]|[Ƈ-ƈ]|Ə|Ɨ|[Ơ-ơ]|[Ư-ư]|Ʒ|[Ǎ-ǜ]|[Ǟ-ǟ]|[Ǣ-ǰ]|[Ǵ-ǵ]|[Ǹ-ǿ]|[Ȓ-ȓ]|[Ș-ț]|[Ȟ-ȟ]|[ȧ-ȳ]|ə|ɨ|ʒ|[ʹ-ʺ]|[ʾ-ʿ]|ˈ|ˌ|[Ḃ-ḃ]|[Ḇ-ḇ]|[Ḋ-ḑ]|[Ḝ-ḫ]|[ḯ-ḷ]|[Ḻ-ḻ]|[Ṁ-ṉ]|[Ṓ-ṛ]|[Ṟ-ṣ]|[Ṫ-ṯ]|[Ẁ-ẇ]|[Ẍ-ẗ]|ẞ|[Ạ-ỹ]|’|‡|€|A̋|C(̀|̄|̆|̈|̕|̣|̦|̨̆)|D̂|F(̀|̄)|G̀|H(̄|̦|̱)|J(́|̌)|K(̀|̂|̄|̇|̕|̛|̦|͟H|͟h)|L(̂|̥|̥̄|̦)|M(̀|̂|̆|̐)|N(̂|̄|̆|̦)|P(̀|̄|̕|̣)|R(̆|̥|̥̄)|S(̀|̄|̛̄|̱)|T(̀|̄|̈|̕|̛)|U̇|Z(̀|̄|̆|̈|̧)|a̋|c(̀|̄|̆|̈|̕|̣|̦|̨̆)|d̂|f(̀|̄)|g̀|h(̄|̦)|j́|k(̀|̂|̄|̇|̕|̛|̦|͟h)|l(̂|̥|̥̄|̦)|m(̀|̂|̆|̐)|n(̂|̄|̆|̦)|p(̀|̄|̕|̣)|r(̆|̥|̥̄)|s(̀|̄|̛̄|̱)|t(̀|̄|̕|̛)|u̇|z(̀|̄|̆|̈|̧)|Ç̆|Û̄|ç̆|û̄|ÿ́|Č(̕|̣)|č(̕|̣)|Ī́|ī́|Ž(̦|̧)|ž(̦|̧)|Ḳ̄|ḳ̄|Ṣ̄|ṣ̄|Ṭ̄|ṭ̄|Ạ̈|ạ̈|Ọ̈|ọ̈|Ụ(̄|̈)|ụ(̄|̈))([\s]|[ -~]|[ -¬]|[®-ž]|[Ƈ-ƈ]|Ə|Ɨ|[Ơ-ơ]|[Ư-ư]|Ʒ|[Ǎ-ǜ]|[Ǟ-ǟ]|[Ǣ-ǰ]|[Ǵ-ǵ]|[Ǹ-ǿ]|[Ȓ-ȓ]|[Ș-ț]|[Ȟ-ȟ]|[ȧ-ȳ]|ə|ɨ|ʒ|[ʹ-ʺ]|[ʾ-ʿ]|ˈ|ˌ|[Ḃ-ḃ]|[Ḇ-ḇ]|[Ḋ-ḑ]|[Ḝ-ḫ]|[ḯ-ḷ]|[Ḻ-ḻ]|[Ṁ-ṉ]|[Ṓ-ṛ]|[Ṟ-ṣ]|[Ṫ-ṯ]|[Ẁ-ẇ]|[Ẍ-ẗ]|ẞ|[Ạ-ỹ]|’|‡|€|A̋|C(̀|̄|̆|̈|̕|̣|̦|̨̆)|D̂|F(̀|̄)|G̀|H(̄|̦|̱)|J(́|̌)|K(̀|̂|̄|̇|̕|̛|̦|͟H|͟h)|L(̂|̥|̥̄|̦)|M(̀|̂|̆|̐)|N(̂|̄|̆|̦)|P(̀|̄|̕|̣)|R(̆|̥|̥̄)|S(̀|̄|̛̄|̱)|T(̀|̄|̈|̕|̛)|U̇|Z(̀|̄|̆|̈|̧)|a̋|c(̀|̄|̆|̈|̕|̣|̦|̨̆)|d̂|f(̀|̄)|g̀|h(̄|̦)|j́|k(̀|̂|̄|̇|̕|̛|̦|͟h)|l(̂|̥|̥̄|̦)|m(̀|̂|̆|̐)|n(̂|̄|̆|̦)|p(̀|̄|̕|̣)|r(̆|̥|̥̄)|s(̀|̄|̛̄|̱)|t(̀|̄|̕|̛)|u̇|z(̀|̄|̆|̈|̧)|Ç̆|Û̄|ç̆|û̄|ÿ́|Č(̕|̣)|č(̕|̣)|Ī́|ī́|Ž(̦|̧)|ž(̦|̧)|Ḳ̄|ḳ̄|Ṣ̄|ṣ̄|Ṭ̄|ṭ̄|Ạ̈|ạ̈|Ọ̈|ọ̈|Ụ(̄|̈)|ụ(̄|̈))*([!-~]|[ -¬]|[®-ž]|[Ƈ-ƈ]|Ə|Ɨ|[Ơ-ơ]|[Ư-ư]|Ʒ|[Ǎ-ǜ]|[Ǟ-ǟ]|[Ǣ-ǰ]|[Ǵ-ǵ]|[Ǹ-ǿ]|[Ȓ-ȓ]|[Ș-ț]|[Ȟ-ȟ]|[ȧ-ȳ]|ə|ɨ|ʒ|[ʹ-ʺ]|[ʾ-ʿ]|ˈ|ˌ|[Ḃ-ḃ]|[Ḇ-ḇ]|[Ḋ-ḑ]|[Ḝ-ḫ]|[ḯ-ḷ]|[Ḻ-ḻ]|[Ṁ-ṉ]|[Ṓ-ṛ]|[Ṟ-ṣ]|[Ṫ-ṯ]|[Ẁ-ẇ]|[Ẍ-ẗ]|ẞ|[Ạ-ỹ]|’|‡|€|A̋|C(̀|̄|̆|̈|̕|̣|̦|̨̆)|D̂|F(̀|̄)|G̀|H(̄|̦|̱)|J(́|̌)|K(̀|̂|̄|̇|̕|̛|̦|͟H|͟h)|L(̂|̥|̥̄|̦)|M(̀|̂|̆|̐)|N(̂|̄|̆|̦)|P(̀|̄|̕|̣)|R(̆|̥|̥̄)|S(̀|̄|̛̄|̱)|T(̀|̄|̈|̕|̛)|U̇|Z(̀|̄|̆|̈|̧)|a̋|c(̀|̄|̆|̈|̕|̣|̦|̨̆)|d̂|f(̀|̄)|g̀|h(̄|̦)|j́|k(̀|̂|̄|̇|̕|̛|̦|͟h)|l(̂|̥|̥̄|̦)|m(̀|̂|̆|̐)|n(̂|̄|̆|̦)|p(̀|̄|̕|̣)|r(̆|̥|̥̄)|s(̀|̄|̛̄|̱)|t(̀|̄|̕|̛)|u̇|z(̀|̄|̆|̈|̧)|Ç̆|Û̄|ç̆|û̄|ÿ́|Č(̕|̣)|č(̕|̣)|Ī́|ī́|Ž(̦|̧)|ž(̦|̧)|Ḳ̄|ḳ̄|Ṣ̄|ṣ̄|Ṭ̄|ṭ̄|Ạ̈|ạ̈|Ọ̈|ọ̈|Ụ(̄|̈)|ụ(̄|̈)))|([!-~]|[ -¬]|[®-ž]|[Ƈ-ƈ]|Ə|Ɨ|[Ơ-ơ]|[Ư-ư]|Ʒ|[Ǎ-ǜ]|[Ǟ-ǟ]|[Ǣ-ǰ]|[Ǵ-ǵ]|[Ǹ-ǿ]|[Ȓ-ȓ]|[Ș-ț]|[Ȟ-ȟ]|[ȧ-ȳ]|ə|ɨ|ʒ|[ʹ-ʺ]|[ʾ-ʿ]|ˈ|ˌ|[Ḃ-ḃ]|[Ḇ-ḇ]|[Ḋ-ḑ]|[Ḝ-ḫ]|[ḯ-ḷ]|[Ḻ-ḻ]|[Ṁ-ṉ]|[Ṓ-ṛ]|[Ṟ-ṣ]|[Ṫ-ṯ]|[Ẁ-ẇ]|[Ẍ-ẗ]|ẞ|[Ạ-ỹ]|’|‡|€|A̋|C(̀|̄|̆|̈|̕|̣|̦|̨̆)|D̂|F(̀|̄)|G̀|H(̄|̦|̱)|J(́|̌)|K(̀|̂|̄|̇|̕|̛|̦|͟H|͟h)|L(̂|̥|̥̄|̦)|M(̀|̂|̆|̐)|N(̂|̄|̆|̦)|P(̀|̄|̕|̣)|R(̆|̥|̥̄)|S(̀|̄|̛̄|̱)|T(̀|̄|̈|̕|̛)|U̇|Z(̀|̄|̆|̈|̧)|a̋|c(̀|̄|̆|̈|̕|̣|̦|̨̆)|d̂|f(̀|̄)|g̀|h(̄|̦)|j́|k(̀|̂|̄|̇|̕|̛|̦|͟h)|l(̂|̥|̥̄|̦)|m(̀|̂|̆|̐)|n(̂|̄|̆|̦)|p(̀|̄|̕|̣)|r(̆|̥|̥̄)|s(̀|̄|̛̄|̱)|t(̀|̄|̕|̛)|u̇|z(̀|̄|̆|̈|̧)|Ç̆|Û̄|ç̆|û̄|ÿ́|Č(̕|̣)|č(̕|̣)|Ī́|ī́|Ž(̦|̧)|ž(̦|̧)|Ḳ̄|ḳ̄|Ṣ̄|ṣ̄|Ṭ̄|ṭ̄|Ạ̈|ạ̈|Ọ̈|ọ̈|Ụ(̄|̈)|ụ(̄|̈)){0,1}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="datatypeE">
+        <xs:annotation>
+            <xs:documentation>Der Datentyp E wurde für alle normativen und erweiterten Schriftzeichen der DIN SPEC entworfen. Ein Einsatzgebiet dieses Datentyps kann der grenzüberschreitende Datenaustausch sein, wenn auch griechische und kyrillische Buchstaben benötigt werden. Er ist somit die technische Umsetzung der Schnittstellenvereinbarung Alle nach DIN SPEC 91379 normativen und nicht-normativen Schriftzeichen. Texte mit Buchstaben oder Nicht-Buchstaben, die in der DIN SPEC nicht enthalten sind, wie z. B. asiatische oder arabische Buchstaben, sind unzulässig.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="([\s]|[ -~]|[ -¬]|[®-ž]|[Ƈ-ƈ]|Ə|ƒ|Ɨ|[Ơ-ơ]|[Ư-ư]|Ʒ|[Ǎ-ǜ]|[Ǟ-ǟ]|[Ǣ-ǰ]|[Ǵ-ǵ]|[Ǹ-ǿ]|[Ȓ-ȓ]|[Ș-ț]|[Ȟ-ȟ]|[ȧ-ȳ]|ə|ɨ|ʒ|ʰ|ʳ|[ʹ-ʺ]|[ʾ-ʿ]|ˆ|ˈ|ˌ|˜|ˢ|Ά|[Έ-Ί]|Ό|[Ύ-Ρ]|[Σ-ώ]|Ѝ|[А-Ъ]|Ь|[Ю-ъ]|ь|[ю-я]|ѝ|ᵈ|ᵗ|[Ḃ-ḃ]|[Ḇ-ḇ]|[Ḋ-ḑ]|[Ḝ-ḫ]|[ḯ-ḷ]|[Ḻ-ḻ]|[Ṁ-ṉ]|[Ṓ-ṛ]|[Ṟ-ṣ]|[Ṫ-ṯ]|[Ẁ-ẇ]|[Ẍ-ẗ]|ẞ|[Ạ-ỹ]|[‘-‚]|[“-„]|[†-‡]|…|‰|[‹-›]|⁰|[⁴-⁹]|[ⁿ-₉]|€|™|∞|[≤-≥]|A̋|C(̀|̄|̆|̈|̕|̣|̦|̨̆)|D̂|F(̀|̄)|G̀|H(̄|̦|̱)|J(́|̌)|K(̀|̂|̄|̇|̕|̛|̦|͟H|͟h)|L(̂|̥|̥̄|̦)|M(̀|̂|̆|̐)|N(̂|̄|̆|̦)|P(̀|̄|̕|̣)|R(̆|̥|̥̄)|S(̀|̄|̛̄|̱)|T(̀|̄|̈|̕|̛)|U̇|Z(̀|̄|̆|̈|̧)|a̋|c(̀|̄|̆|̈|̕|̣|̦|̨̆)|d̂|f(̀|̄)|g̀|h(̄|̦)|j́|k(̀|̂|̄|̇|̕|̛|̦|͟h)|l(̂|̥|̥̄|̦)|m(̀|̂|̆|̐)|n(̂|̄|̆|̦)|p(̀|̄|̕|̣)|r(̆|̥|̥̄)|s(̀|̄|̛̄|̱)|t(̀|̄|̕|̛)|u̇|z(̀|̄|̆|̈|̧)|Ç̆|Û̄|ç̆|û̄|ÿ́|Č(̕|̣)|č(̕|̣)|Ī́|ī́|Ž(̦|̧)|ž(̦|̧)|Ḳ̄|ḳ̄|Ṣ̄|ṣ̄|Ṭ̄|ṭ̄|Ạ̈|ạ̈|Ọ̈|ọ̈|Ụ(̄|̈)|ụ(̄|̈))*"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="Absender_Typ">
+        <xs:sequence>
+            <xs:element name="Bezeichnung" type="Namenstring255_Typ" minOccurs="0"/>
+            <xs:element name="Ansprechpartner" type="Namenstring255_Typ" minOccurs="0"/>
+            <xs:element name="Anschrift" type="Adressstring255_Typ" minOccurs="0"/>
+            <xs:element name="Telefon" type="Adressstring255_Typ" minOccurs="0"/>
+            <xs:element name="EMail" type="Adressstring255_Typ" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="Absender_ID" type="FreitextID_Typ" use="required"/>
+        <xs:attribute name="Software_ID" type="Freitext255_Typ" use="required"/>
+        <xs:attribute name="Software_Version" type="Freitext255_Typ" use="required"/>
+        <xs:attribute name="Installations_ID" type="Freitext255_Typ" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="Patienten_Adresse_Typ">
+        <xs:annotation>
+            <xs:documentation>Vollständiger Typ zur Restriktion in Patienten_Adresse_Melder_Typ</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Strasse" type="Adressstring255_Typ" minOccurs="0"/>
+            <xs:element name="Hausnummer" type="Adressstring255_Typ" minOccurs="0"/>
+            <xs:element name="Land" type="ISO3166Alpha2Code_Typ" minOccurs="0"/>
+            <xs:element name="PLZ" type="Adressstring10_Typ" minOccurs="0"/>
+            <xs:element name="Ort" type="Adressstring255_Typ" minOccurs="0"/>
+            <xs:element name="Gueltig_von" type="Datum_Tag_oder_Monat_oder_Jahr_oder_nicht_genau_Typ" minOccurs="0"/>
+            <xs:element name="Gueltig_bis" type="Datum_Tag_oder_Monat_oder_Jahr_oder_nicht_genau_Typ" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Patienten_Adresse_Melder_Typ">
+        <xs:complexContent>
+            <xs:restriction base="Patienten_Adresse_Typ">
+                <xs:sequence>
+                    <xs:element name="Strasse" type="Adressstring255_Typ" minOccurs="0"/>
+                    <xs:element name="Hausnummer" type="Adressstring255_Typ" minOccurs="0"/>
+                    <xs:element name="Land" type="ISO3166Alpha2Code_Typ" minOccurs="0"/>
+                    <xs:element name="PLZ" type="Adressstring10_Typ" minOccurs="0"/>
+                    <xs:element name="Ort" type="Adressstring255_Typ" minOccurs="0"/>
+                </xs:sequence>
+            </xs:restriction>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:simpleType name="Meldebegruendung_Typ">
+        <xs:annotation>
+            <xs:documentation>Widerspruch/Einwilligung des Patienten</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="I">
+                <xs:annotation>
+                    <xs:documentation>Patientin/Patient wurde informiert und hat nicht widersprochen</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="A">
+                <xs:annotation>
+                    <xs:documentation>Ausnahme: Patientenunterrichtung entfallen wegen möglicher gesundheitlicher Nachteile</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="D">
+                <xs:annotation>
+                    <xs:documentation>D = Meldung von Ärzten ohne unmittelbaren Patientenkontakt</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="W">
+                <xs:annotation>
+                    <xs:documentation>Patient hat der personenbezogenen Speicherung widersprochen</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="V">
+                <xs:annotation>
+                    <xs:documentation>Verstorben</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Zertifizierung_Typ">
+        <xs:annotation>
+            <xs:documentation>Die Kennzeichnung dürfte normalerweise bei Diagnosemeldungen oder Verlaufsmeldungen erfolgen, da diese die relevanten Ereingnisse abbilden.
+                Hinweis: es fehlt Patientenfall (Hämato-onkologische Neoplasien)</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="1">
+                <xs:annotation>
+                    <xs:documentation>Zentrumsfall/Primärfall</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2">
+                <xs:annotation>
+                    <xs:documentation>Zentrumsfall/kein Primärfall</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3">
+                <xs:annotation>
+                    <xs:documentation>nicht Zentrumsfall</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="Tumorzuordnung_Typ">
+        <xs:sequence>
+            <xs:element name="Primaertumor_ICD" type="Tumor_ICD_Typ"/>
+            <xs:element name="Diagnosedatum" type="Datum_Tag_oder_Monat_oder_Jahr_oder_nicht_genau_Typ"/>
+            <xs:element name="Seitenlokalisation" type="Seitenlokalisation_Typ" minOccurs="0"/>
+            <xs:element name="Morphologie_ICD_O" type="Morphologie_ICD_O_Typ" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="Tumor_ID" type="FreitextID_Typ" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="Patienten_Stammdaten_Melder_Typ">
+        <xs:annotation>
+            <xs:documentation>Typ zur Verwendung in Meldungen, im RüD wird ein abweichender Typ mit Menge_Adresse verwendet werden</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="Versichertendaten_GKV" type="Versichertendaten_GKV_Typ"/>
+                <xs:element name="Versichertendaten_PKV" type="Versichertendaten_PKV_Typ"/>
+                <xs:element name="Versichertendaten_Sonstige" type="Versichertendaten_Sonstige_Typ"/>
+            </xs:choice>
+            <xs:element name="Nachname" type="Namenstring255_Typ"/>
+            <xs:element name="Titel" type="Namenstring255_Typ" minOccurs="0"/>
+            <xs:element name="Namenszusatz" type="Namenstring255_Typ" minOccurs="0"/>
+            <xs:element name="Namensvorsatz" type="Namenstring255_Typ" minOccurs="0"/>
+            <xs:element name="Vornamen" type="Namenstring255_Typ"/>
+            <xs:element name="Geburtsname" type="Namenstring255_Typ" minOccurs="0"/>
+            <xs:element name="Menge_Frueherer_Name" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Frueherer_Name" type="Namenstring255_Typ" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Geschlecht">
+                <xs:annotation>
+                    <xs:documentation>
+                        Es wird, wenn möglich, das Geschlecht verwendet, wie es im Melderegister und auf der Gesundheitskarte vermerkt ist.
+                        Es ist zu beachten, dass X=unbestimmtes Geschlecht (amtlich: keine Angabe) einer expliziten Angabe im Personenstandsregister entspricht und auf keinen Fall mit U=unbekannt gleichzusetzen ist.
+                        "Unbekannt" bedeutet, dass dem Melder das Geschlecht tatsächlich unbekannt ist und stellt eine absolute Ausnahmesituation dar, da beispielsweise eine Versichertenkarte das amtliche Geschlecht enthält.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="M">
+                            <xs:annotation>
+                                <xs:documentation>Männlich</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="W">
+                            <xs:annotation>
+                                <xs:documentation>Weiblich</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="D">
+                            <xs:annotation>
+                                <xs:documentation>Divers</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="X">
+                            <xs:annotation>
+                                <xs:documentation>keine Angabe / unbestimmt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>Unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Geburtsdatum" type="Datum_Tag_oder_Monat_oder_Jahr_oder_nicht_genau_Typ"/>
+            <xs:element name="Adresse" type="Patienten_Adresse_Melder_Typ"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Menge_Zusatzitem_Typ">
+        <xs:sequence>
+            <xs:element name="Zusatzitem" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Datum" type="Datum_Tag_oder_Monat_oder_Jahr_oder_nicht_genau_Typ" minOccurs="0"/>
+                        <xs:element name="Art" type="Freitext255_Typ"/>
+                        <xs:element name="Wert" type="Freitext255_Typ" minOccurs="0"/>
+                        <xs:element name="Bemerkung" type="FreitextAnmerkung_Typ" minOccurs="0"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="Zulaessiger_Datumsbereich_Typ">
+        <xs:restriction base="xs:date">
+            <xs:minInclusive value="1890-01-01"/>
+            <xs:maxInclusive value="2025-12-31"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="Datum_Tag_oder_Monat_oder_Jahr_oder_nicht_genau_Typ">
+        <xs:simpleContent>
+            <xs:extension base="Zulaessiger_Datumsbereich_Typ">
+                <xs:attribute name="Datumsgenauigkeit" use="required">
+                    <xs:simpleType>
+                        <xs:annotation>
+                            <xs:documentation>
+                                Bei allen geschätzten Angaben darf ein plausibles, genau wirkendes Datum eingetragen werden.
+                                D.h. der vielfach praktizierten Konvention monatsgenau bedeutet Einsetzen des 15. und Jahresgenau bedeutet Einsetzen des 01.07. muss nicht gefolgt werden.
+                                Im Gegenteil können durch Abweichen von dieser Konvention Verletzungen der Datumshierarchien (z.B. ungenaues Diagnosedatum nach genauem Therapiedatum) vermieden werden.
+                                Es ist Sache des Registers, ungenaue Angaben bei bestimmten Anlässen, z.B. Auswertungen, ggf. gesondert zu handhaben.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="E">
+                                <xs:annotation>
+                                    <xs:documentation>exakt (entspricht taggenau)</xs:documentation>
+                                </xs:annotation>
+                            </xs:enumeration>
+                            <xs:enumeration value="T">
+                                <xs:annotation>
+                                    <xs:documentation>Tag geschätzt (entspricht monatsgenau)</xs:documentation>
+                                </xs:annotation>
+                            </xs:enumeration>
+                            <xs:enumeration value="M">
+                                <xs:annotation>
+                                    <xs:documentation>Monat geschätzt (entspricht jahrgenau)</xs:documentation>
+                                </xs:annotation>
+                            </xs:enumeration>
+                            <xs:enumeration value="V">
+                                <xs:annotation>
+                                    <xs:documentation>vollständig geschätzt (genaue Angabe zum Jahr nicht möglich)</xs:documentation>
+                                </xs:annotation>
+                            </xs:enumeration>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="Datum_Tag_oder_Monat_genau_Typ">
+        <xs:simpleContent>
+            <xs:extension base="Zulaessiger_Datumsbereich_Typ">
+                <xs:attribute name="Datumsgenauigkeit" use="required">
+                    <xs:simpleType>
+                        <xs:annotation>
+                            <xs:documentation>siehe Dokumentation zu Datum_Tag_oder_Monat_oder_Jahr_oder_nicht_genau_Typ</xs:documentation>
+                        </xs:annotation>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="E">
+                                <xs:annotation>
+                                    <xs:documentation>exakt (entspricht taggenau)</xs:documentation>
+                                </xs:annotation>
+                            </xs:enumeration>
+                            <xs:enumeration value="T">
+                                <xs:annotation>
+                                    <xs:documentation>Tag geschätzt (entspricht monatsgenau)</xs:documentation>
+                                </xs:annotation>
+                            </xs:enumeration>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:simpleType name="Datum_Tag_genau_Typ">
+        <xs:restriction base="Zulaessiger_Datumsbereich_Typ"/>
+    </xs:simpleType>
+    <xs:simpleType name="Datum_nur_Jahr_Typ">
+        <xs:restriction base="xs:gYear">
+            <xs:minInclusive value="1890"/>
+            <xs:maxInclusive value="2025"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="JNU_Typ">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="J">
+                <xs:annotation>
+                    <xs:documentation>Ja</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="N">
+                <xs:annotation>
+                    <xs:documentation>Nein</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="U">
+                <xs:annotation>
+                    <xs:documentation>Unbekannt</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="JN_Typ">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="J">
+                <xs:annotation>
+                    <xs:documentation>Ja</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="N">
+                <xs:annotation>
+                    <xs:documentation>Nein</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ICD_Code_Typ">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z]\d\d(\.\d(\d)?)?"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="Tumor_ICD_Typ">
+        <xs:sequence>
+            <xs:element name="Code">
+                <xs:simpleType>
+                    <xs:restriction base="ICD_Code_Typ">
+                        <xs:pattern value="[CD]\d\d(\.\d(\d)?)?|M72.4"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Version" type="ICD_Version_Typ"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Allgemein_ICD_Typ">
+        <xs:sequence>
+            <xs:element name="Code" type="ICD_Code_Typ"/>
+            <xs:element name="Version" type="ICD_Version_Typ"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="ICD_Version_Typ">
+        <xs:annotation>
+            <xs:documentation>
+                ICD 10 Version 2006 WHO (gültig bis 2010),
+                ICD 10 Version 2011 WHO (gültig bis 2012),
+                ICD 10 Version 2013 WHO (gültig bis 2015),
+                ICD 10 Version 2016 WHO (gültig bis 2018),
+                ICD 10 Version 2019 WHO (letzte Version, wird nur noch in Ausnahmefällen aktualisiert)
+                Sonstige, falls andere bzw. ältere Versionen verwendet werden
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="(10 20\d{2} ((GM)|(WHO))|Sonstige)"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Ziffern9_Typ">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d{9}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="Ident_Nummern_Typ">
+        <xs:sequence>
+            <xs:element name="IKNR" type="Ziffern9_Typ" minOccurs="0"/>
+            <xs:element name="LANR" type="Ziffern9_Typ" minOccurs="0"/>
+            <xs:element name="BSNR" type="Ziffern9_Typ" minOccurs="0"/>
+            <xs:element name="ZANR" type="Ziffern9_Typ" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Melder_Typ">
+        <xs:sequence>
+            <xs:element name="Ident_Nummern" type="Ident_Nummern_Typ" minOccurs="0"/>
+            <xs:element name="KH_Abt_Station_Praxis" type="Adressstring255_Typ" minOccurs="0"/>
+            <xs:element name="Arztname" type="Namenstring255_Typ" minOccurs="0"/>
+            <xs:element name="Anschrift" type="Adressstring255_Typ" minOccurs="0"/>
+            <xs:element name="PLZ" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:pattern value="\d{5}"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Ort" type="Adressstring255_Typ" minOccurs="0"/>
+            <xs:element name="Bankname" type="Adressstring255_Typ" minOccurs="0"/>
+            <xs:element name="Kontoinhaber" type="Namenstring255_Typ" minOccurs="0"/>
+            <xs:element name="BIC" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="11"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="IBAN" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="34"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="ID" type="FreitextID_Typ" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="Morphologie_ICD_O_Typ">
+        <xs:sequence>
+            <xs:element name="Code">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:pattern value="\d\d\d\d/\d"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Version">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="31">
+                            <xs:annotation>
+                                <xs:documentation>ICD-O-3, 2003</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="32">
+                            <xs:annotation>
+                                <xs:documentation>ICD-O-3, 1. Revision 2014</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="33">
+                            <xs:annotation>
+                                <xs:documentation>ICD-O-3, 2. Revision 2019</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="bb">
+                            <xs:annotation>
+                                <xs:documentation>Neue Codes aus den WHO-Klassifikationen (BlueBooks)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Histologie_Typ">
+        <xs:sequence>
+            <xs:element name="Tumor_Histologiedatum" type="Datum_Tag_oder_Monat_oder_Jahr_oder_nicht_genau_Typ" minOccurs="0"/>
+            <xs:element name="Histologie_EinsendeNr" type="Freitext255_Typ" minOccurs="0"/>
+            <xs:element name="Morphologie_ICD_O" type="Morphologie_ICD_O_Typ" minOccurs="0" maxOccurs="5"/>
+            <xs:element name="Morphologie_Freitext" type="Freitext255_Typ" minOccurs="0"/>
+            <xs:element name="Grading">
+                <xs:annotation>
+                    <xs:documentation>
+                        Das histopathologische Grading von Tumoren wird durchgeführt, um Anhaltspunkte betreffend ihrer Aggressivität zu erhalten, die im Bezug zur Prognose und zur Behandlung steht. Das Grading sollte den Empfehlungen der WHO-Klassifikation maligner Tumoren folgen.
+                        0 = Malignes Melanom der Konjunktiva
+                        1 = Gut differenziert
+                        2 = Mäßig differenziert
+                        3 = Schlecht differenziert
+                        4 = Undifferenziert
+                        X = Nicht bestimmbar
+                        L = Low grade (G1 oder G2)
+                        M = Intermediate (G2 oder G3)
+                        H = High grade (G3 oder G4)
+                        B = Borderline
+                        U = Unbekannt
+                        T = Trifft nicht zu
+                        Bei der Klassifikation sind die einschlägigen Regeln der Literatur (TNM) zu beachten.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="0">
+                            <xs:annotation>
+                                <xs:documentation>Malignes Melanom der Konjunktiva</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="1">
+                            <xs:annotation>
+                                <xs:documentation>Gut differenziert</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="2">
+                            <xs:annotation>
+                                <xs:documentation>Mäßig differenziert</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="3">
+                            <xs:annotation>
+                                <xs:documentation>Schlecht differenziert</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="4">
+                            <xs:annotation>
+                                <xs:documentation>Undifferenziert</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="X">
+                            <xs:annotation>
+                                <xs:documentation>Nicht bestimmbar</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="L">
+                            <xs:annotation>
+                                <xs:documentation>Low grade (G1 oder G2)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="M">
+                            <xs:annotation>
+                                <xs:documentation>Intermediate (G2 oder G3)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="H">
+                            <xs:annotation>
+                                <xs:documentation>High grade (G3 oder G4)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="B">
+                            <xs:annotation>
+                                <xs:documentation>Borderline</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>Unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="T">
+                            <xs:annotation>
+                                <xs:documentation>Trifft nicht zu</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="LK_untersucht" type="xs:nonNegativeInteger" minOccurs="0"/>
+            <xs:element name="LK_befallen" type="xs:nonNegativeInteger" minOccurs="0"/>
+            <xs:element name="Sentinel_LK_untersucht" type="xs:nonNegativeInteger" minOccurs="0"/>
+            <xs:element name="Sentinel_LK_befallen" type="xs:nonNegativeInteger" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="Histologie_ID" type="FreitextID_Typ" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="Menge_FM_Typ">
+        <xs:sequence>
+            <xs:element name="Fernmetastase" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Diagnosedatum" type="Datum_Tag_oder_Monat_oder_Jahr_oder_nicht_genau_Typ"/>
+                        <xs:element name="Lokalisation">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Lokalisation der Fernmetastase
+                                    PUL = Lunge
+                                    OSS = Knochen
+                                    HEP = Leber
+                                    BRA = Hirn
+                                    LYM = Lymphknoten
+                                    MAR = Knochenmark
+                                    PLE = Pleura
+                                    PER = Peritoneum
+                                    ADR = Nebennieren
+                                    SKI = Haut
+                                    OTH = Andere Organe
+                                    GEN = Generalisierte Metastasierung
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="PUL">
+                                        <xs:annotation>
+                                            <xs:documentation>Lunge</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="OSS">
+                                        <xs:annotation>
+                                            <xs:documentation>Knochen</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="HEP">
+                                        <xs:annotation>
+                                            <xs:documentation>Leber</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="BRA">
+                                        <xs:annotation>
+                                            <xs:documentation>Hirn</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="LYM">
+                                        <xs:annotation>
+                                            <xs:documentation>Lymphknoten</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="MAR">
+                                        <xs:annotation>
+                                            <xs:documentation>Knochenmark</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="PLE">
+                                        <xs:annotation>
+                                            <xs:documentation>Pleura</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="PER">
+                                        <xs:annotation>
+                                            <xs:documentation>Peritoneum</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ADR">
+                                        <xs:annotation>
+                                            <xs:documentation>Nebennieren</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="SKI">
+                                        <xs:annotation>
+                                            <xs:documentation>Haut</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="OTH">
+                                        <xs:annotation>
+                                            <xs:documentation>Andere Organe</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="GEN">
+                                        <xs:annotation>
+                                            <xs:documentation>Generalisierte Metastasierung</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Nebenwirkung_Typ">
+        <xs:choice>
+            <xs:element name="Grad_maximal2_oder_unbekannt">
+                <xs:annotation>
+                    <xs:documentation>
+                        Gibt an, zu welchem Schweregrad von Nebenwirkungen es bei der Bestrahlung gekommen ist (sogenannte akute Nebenwirkungen bis zum 90 Tag nach Bestrahlungsbeginn)
+                        Art der Nebenwirkung nach CTC + Schweregrad
+                        K = keine
+                        1 = mild
+                        2 = moderat
+                        U = unbekannt
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="K">
+                            <xs:annotation>
+                                <xs:documentation>keine</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="1">
+                            <xs:annotation>
+                                <xs:documentation>mild</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="2">
+                            <xs:annotation>
+                                <xs:documentation>moderat</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Menge_Nebenwirkung">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Nebenwirkung" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="Art">
+                                        <xs:complexType>
+                                            <xs:choice>
+                                                <xs:element name="Bezeichnung" type="Adressstring255_Typ"/>
+                                                <xs:element name="MedDRA_Code">
+                                                    <xs:simpleType>
+                                                        <xs:restriction base="xs:string">
+                                                            <xs:pattern value="\d{8}"/>
+                                                        </xs:restriction>
+                                                    </xs:simpleType>
+                                                </xs:element>
+                                            </xs:choice>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="Grad">
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:enumeration value="3">
+                                                    <xs:annotation>
+                                                        <xs:documentation>schwerwiegend</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="4">
+                                                    <xs:annotation>
+                                                        <xs:documentation>lebensbedrohlich</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="5">
+                                                    <xs:annotation>
+                                                        <xs:documentation>tödlich</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:element>
+                                    <xs:element name="Version">
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:enumeration value="4">
+                                                    <xs:annotation>
+                                                        <xs:documentation>CTCAE Version 4</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="4.03">
+                                                    <xs:annotation>
+                                                        <xs:documentation>CTCAE Version 4.03</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="5.0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>CTCAE Version 5.0</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="Sonstige">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Falls andere bzw. ältere Versionen verwendet werden</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="Residualstatus_Typ">
+        <xs:sequence>
+            <xs:element name="Lokale_Beurteilung_Residualstatus" type="R_Typ" minOccurs="0"/>
+            <xs:element name="Gesamtbeurteilung_Residualstatus" type="R_Typ" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="R_Typ">
+        <xs:annotation>
+            <xs:documentation>R0/1/2/X werden im TNM-Buch beschrieben, R1(cy+) und R1(is) stammen aus dem TNM-Supplement.
+                Wichtig ist zu wissen, dass RX ein expliziter Code ist, während U tatsächlich das Nicht-Vorhandensein der Information kennzeichnet</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="R0">
+                <xs:annotation>
+                    <xs:documentation>kein Residualtumor</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="R1">
+                <xs:annotation>
+                    <xs:documentation>mikroskopischer Residualtumor</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="R2">
+                <xs:annotation>
+                    <xs:documentation>makroskopischer Residualtumor</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="R1(is)">
+                <xs:annotation>
+                    <xs:documentation>In-Situ-Rest</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="R1(cy+)">
+                <xs:annotation>
+                    <xs:documentation>cytologischer Rest</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="RX">
+                <xs:annotation>
+                    <xs:documentation>Vorhandensein von Residualtumor kann nicht beurteilt werden</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="U">
+                <xs:annotation>
+                    <xs:documentation>Residualtumorstatus ist nicht bekannt</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="Menge_Weitere_Klassifikation_Typ">
+        <xs:sequence>
+            <xs:element name="Weitere_Klassifikation" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Datum" type="Datum_Tag_oder_Monat_genau_Typ" minOccurs="0"/>
+                        <xs:element name="Name" type="Freitext255_Typ"/>
+                        <xs:element name="Stadium" type="Freitext30_Typ"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Menge_Genetik_Typ">
+        <xs:sequence>
+            <xs:element name="Genetische_Variante" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>Hier sollen nur Untersuchungen übermittelt werden, die nicht in den Modulen spezifiziert sind</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Datum" type="Datum_Tag_oder_Monat_genau_Typ" minOccurs="0"/>
+                        <xs:element name="Bezeichnung" type="Freitext255_Typ"/>
+                        <xs:choice>
+                            <xs:element name="Auspraegung">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Die Ausprägungen können in Abhängigkeit von der Art der Untersuchung unterschiedliche Wertebereiche und Bezeichnungen haben.
+                                        Für einige Untersuchungen wird die Auswahlliste keine passenden Werte haben, da wahrscheinlich zu keinem Zeitpunkt eine vollständige Ausprägungsliste erstellbar ist.
+                                        Dafür ist statt einer Ausprägung das Freitextfeld Sonstige_Auspraegung vorgesehen.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:enumeration value="M">
+                                            <xs:annotation>
+                                                <xs:documentation>Mutation/positiv</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:enumeration>
+                                        <xs:enumeration value="W">
+                                            <xs:annotation>
+                                                <xs:documentation>Wildtyp/nicht mutiert/negativ</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:enumeration>
+                                        <xs:enumeration value="P">
+                                            <xs:annotation>
+                                                <xs:documentation>Polymorphismus</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:enumeration>
+                                        <xs:enumeration value="N">
+                                            <xs:annotation>
+                                                <xs:documentation>nicht bestimmbar</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:enumeration>
+                                        <xs:enumeration value="U">
+                                            <xs:annotation>
+                                                <xs:documentation>unbekannt</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:enumeration>
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
+                            <xs:element name="Sonstige_Auspraegung" type="Freitext255_Typ"/>
+                        </xs:choice>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Modul_Allgemein_Typ">
+        <xs:sequence>
+            <xs:element name="Sozialdienstkontakt" type="Datum_N_Typ" minOccurs="0"/>
+            <xs:element name="Psychoonkologiekontakt" type="Datum_N_Typ" minOccurs="0"/>
+            <xs:element name="Studienteilnahme" type="Datum_NU_Typ" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Modul_Mamma_patho_Typ">
+        <xs:complexContent>
+            <xs:restriction base="Modul_Mamma_Typ">
+                <xs:sequence>
+                    <xs:element name="HormonrezeptorStatus_Oestrogen" type="Hormonrezeptor_Typ" minOccurs="0"/>
+                    <xs:element name="HormonrezeptorStatus_Progesteron" type="Hormonrezeptor_Typ" minOccurs="0"/>
+                    <xs:element name="Her2neuStatus" type="Hormonrezeptor_Typ" minOccurs="0"/>
+                    <xs:element name="TumorgroesseInvasiv" type="Zahl_3stellig_Typ" minOccurs="0"/>
+                    <xs:element name="TumorgroesseDCIS" type="Zahl_3stellig_Typ" minOccurs="0"/>
+                </xs:sequence>
+            </xs:restriction>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="Modul_Mamma_Typ">
+        <xs:annotation>
+            <xs:documentation>Der Einschluss der vollständigen Module Mamma und Darm, sowie Allgemein in verschiedenen Abschnitten des Datensatzes ist nicht so zu verstehen, dass an allen Stellen alle Felder zu befüllen sind, vielmehr soll die Möglichkeit eröffnet werden, z. B. im Element "Diagnose" alle Informationen zu übermitteln, ohne für einige Modul-Felder eine im Übrigen leere OP anlegen zu müssen, oder umgekehrt.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Praetherapeutischer_Menopausenstatus" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Prätherapeutischer Menopausenstatus der Patientin Postmenopausal bedeutet mehr als ein Jahr keine Menstruationsblutung oder Estradiol (E2) und Follikelstimulierendes Hormon (FSH) im eindeutigen postmenopausalen Bereich.
+                        1 = Prämenopausal
+                        3 = Postmenopausal
+                        U = Unbekannt
+                        Hinweis: Prämenopausal umfasst Perimenopausal
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="1">
+                            <xs:annotation>
+                                <xs:documentation>Prämenopausal</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="3">
+                            <xs:annotation>
+                                <xs:documentation>Postmenopausal</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>Unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="HormonrezeptorStatus_Oestrogen" type="Hormonrezeptor_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Rezeptorstatus Positiv/Negativ (gemäß: Immun reaktiver Score (IRS) Remmele W et al. 1987)
+                        P = Positiv (IRS &gt;= 1)
+                        N = Negativ
+                        U = Unbekannt
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="HormonrezeptorStatus_Progesteron" type="Hormonrezeptor_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Rezeptorstatus Positiv/Negativ (gemäß: Immunreaktiver Score (IRS) Remmele W et al. 1987).
+                        P = Positiv (IRS &gt;= 1)
+                        N = Negativ
+                        U = Unbekannt
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Her2neuStatus" type="Hormonrezeptor_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Rezeptorstatus Positiv/Negativ (gemäß immunreaktiven Scores nach Leitlinie)
+                        P = Positiv, d. h.
+                        IHC +++ oder
+                        IHC ++ und ISH (FISH, CISH o. Ä.) positiv
+                        N = Negativ
+                        U = Unbekannt
+                        Bei FISH "borderline" muss die Festlegung auf negativ oder positiv durch den Kliniker in Absprache mit dem Pathologen erfolgen.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="PraeopDrahtmarkierung" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Es wurde eine präoperative Drahtmarkierung gesteuert durch das angegebene bildgebende Verfahren durchgeführt.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="M">
+                            <xs:annotation>
+                                <xs:documentation>Mammografie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="S">
+                            <xs:annotation>
+                                <xs:documentation>Sonografie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="T">
+                            <xs:annotation>
+                                <xs:documentation>MRT</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="N">
+                            <xs:annotation>
+                                <xs:documentation>Keine Drahtmarkierung durch Bildgebung</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>Unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="IntraopPraeparatkontrolle" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Das Präparat wird intraoperativ mammografiert/sonografiert nach präoperativer Drahtmarkierung durch Mammografie oder Sonografie.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="M">
+                            <xs:annotation>
+                                <xs:documentation>Mammografie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="S">
+                            <xs:annotation>
+                                <xs:documentation>Sonografie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="N">
+                            <xs:annotation>
+                                <xs:documentation>Nein</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>Unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="TumorgroesseInvasiv" type="Zahl_3stellig_Typ" minOccurs="0"/>
+            <xs:element name="TumorgroesseDCIS" type="Zahl_3stellig_Typ" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="RektumQualitaetTME_Typ">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="1">
+                <xs:annotation>
+                    <xs:documentation>Grad 1 (gut)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2">
+                <xs:annotation>
+                    <xs:documentation>Grad 2 (moderat)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3">
+                <xs:annotation>
+                    <xs:documentation>Grad 3 (schlecht)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="P">
+                <xs:annotation>
+                    <xs:documentation>PME durchgeführt</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="L">
+                <xs:annotation>
+                    <xs:documentation>Lokale Exzision durchgeführt</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="A">
+                <xs:annotation>
+                    <xs:documentation>Andere Operation durchgeführt</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="U">
+                <xs:annotation>
+                    <xs:documentation>Unbekannt</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="RASMutation_Typ">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="W">
+                <xs:annotation>
+                    <xs:documentation>Wildtyp</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="M">
+                <xs:annotation>
+                    <xs:documentation>Mutation</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="U">
+                <xs:annotation>
+                    <xs:documentation>Unbekannt</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="N">
+                <xs:annotation>
+                    <xs:documentation>Nicht untersucht</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="Modul_Darm_patho_Typ">
+        <xs:complexContent>
+            <xs:restriction base="Modul_Darm_Typ">
+                <xs:sequence>
+                    <xs:element name="RektumAbstandAboralerResektionsrand" type="Zahl_3stellig_Typ" minOccurs="0"/>
+                    <xs:element name="RektumAbstandCircResektionsebene" type="Zahl_3stellig_Typ" minOccurs="0"/>
+                    <xs:element name="RektumQualitaetTME" type="RektumQualitaetTME_Typ" minOccurs="0"/>
+                    <xs:element name="RASMutation" type="RASMutation_Typ" minOccurs="0"/>
+                </xs:sequence>
+            </xs:restriction>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="Modul_Darm_Typ">
+        <xs:annotation>
+            <xs:documentation>Der Einschluss der vollständigen Module Mamma und Darm, sowie Allgemein in verschiedenen Abschnitten des Datensatzes ist nicht so zu verstehen, dass an allen Stellen alle Felder zu befüllen sind, vielmehr soll die Möglichkeit eröffnet werden, z. B. im Element "Diagnose" alle Informationen zu übermitteln, ohne für einige Modul-Felder eine im Übrigen leere OP anlegen zu müssen, oder umgekehrt.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="RektumAbstandAnokutanlinie" type="Zahl_3stellig_Typ" minOccurs="0"/>
+            <xs:element name="RektumAbstandAboralerResektionsrand" type="Zahl_3stellig_Typ" minOccurs="0"/>
+            <xs:element name="RektumAbstandCircResektionsebene" type="Zahl_3stellig_Typ" minOccurs="0"/>
+            <xs:element name="RektumQualitaetTME" type="RektumQualitaetTME_Typ" minOccurs="0"/>
+            <xs:element name="RektumMRTDuennschichtAngabemesorektaleFaszie" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:pattern value="0|[1-9](\d)?|[DNU]"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="ArtEingriff" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Modalität der Eingriffsdurchführung</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="E">
+                            <xs:annotation>
+                                <xs:documentation>Elektiveingriff</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="N">
+                            <xs:annotation>
+                                <xs:documentation>Notfalleingriff</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>Unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="RektumAnzeichnungStomaposition" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Präoperative Anzeichnung der Stomaposition</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="D">
+                            <xs:annotation>
+                                <xs:documentation>Anzeichnung durchgeführt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="N">
+                            <xs:annotation>
+                                <xs:documentation>Anzeichnung nicht durchgeführt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="K">
+                            <xs:annotation>
+                                <xs:documentation>Kein Stoma</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="S">
+                            <xs:annotation>
+                                <xs:documentation>Stoma angelegt, Anzeichnung nicht bekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>Unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="GradRektumAnastomoseninsuffizienz" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Rektum:
+                        Grad A (keine therapeutische Konsequenz)
+                        Grad B (Antibiotikagabe oder interventionelle Drainage oder transanale Lavage/Drainage)
+                        Grad C ((Re)-Laparotomie)
+                        Für Indikator Anastomoseninsuffizienz nach elektivem Eingriff mit Anastomosenanlage
+                        Ausprägung gem. Rahbari, N.N., et al., Definition and grading of anastomotic leakage following anterior resection of the rectum: a proposal by the International Study Group of Rectal Cancer.Surgery, 2010. 147(3): p. 339-51.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="B">
+                            <xs:annotation>
+                                <xs:documentation>Anastomoseninsuffizienz Grad B</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="C">
+                            <xs:annotation>
+                                <xs:documentation>Anastomoseninsuffizienz Grad C</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="K">
+                            <xs:annotation>
+                                <xs:documentation>Keine Insuffizienz oder höchstens Grad A</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>Unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="ASA" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="1">
+                            <xs:annotation>
+                                <xs:documentation>Normaler, ansonsten gesunder Patient</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="2">
+                            <xs:annotation>
+                                <xs:documentation>Patient mit leichter Allgemeinerkrankung</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="3">
+                            <xs:annotation>
+                                <xs:documentation>Patient mit schwerer Allgemeinerkrankung und Leistungseinschränkung</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="4">
+                            <xs:annotation>
+                                <xs:documentation>Patient mit inaktivierender Allgemeinerkrankung, ständige Lebensbedrohung</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="5">
+                            <xs:annotation>
+                                <xs:documentation>Moribunder Patient</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="RASMutation" type="RASMutation_Typ" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="GleasonScore_Typ">
+        <xs:annotation>
+            <xs:documentation>
+                Wert des Gleason-Score:
+                GleasonGradPrimaer + GleasonGradSekundaer = GleasonScoreErgebnis
+                mod. nach ISUP 2005 bei primärem Ca-Nachweis und im OP-Präparat
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="GradPrimaer" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>primärer Gleason Grad zum Gleason-Score</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="1"/>
+                        <xs:enumeration value="2"/>
+                        <xs:enumeration value="3"/>
+                        <xs:enumeration value="4"/>
+                        <xs:enumeration value="5"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="GradSekundaer" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>sekundärer Gleason Grad zum Gleason-Score</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="1"/>
+                        <xs:enumeration value="2"/>
+                        <xs:enumeration value="3"/>
+                        <xs:enumeration value="4"/>
+                        <xs:enumeration value="5"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="ScoreErgebnis" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Ergebnis Gleason-Score</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="2"/>
+                        <xs:enumeration value="3"/>
+                        <xs:enumeration value="4"/>
+                        <xs:enumeration value="5"/>
+                        <xs:enumeration value="6"/>
+                        <xs:enumeration value="7"/>
+                        <xs:enumeration value="7a"/>
+                        <xs:enumeration value="7b"/>
+                        <xs:enumeration value="8"/>
+                        <xs:enumeration value="9"/>
+                        <xs:enumeration value="10"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="AnlassGleasonScore_Typ">
+        <xs:annotation>
+            <xs:documentation>Anlass der Bestimmung des Scores OP oder Stanze</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="O">
+                <xs:annotation>
+                    <xs:documentation>Op</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="S">
+                <xs:annotation>
+                    <xs:documentation>Stanze</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="U">
+                <xs:annotation>
+                    <xs:documentation>Unbekannt</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="AnzahlStanzen_Typ">
+        <xs:restriction base="xs:nonNegativeInteger">
+            <xs:maxExclusive value="100"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="CaBefallStanze_Typ">
+        <xs:annotation>
+            <xs:documentation>Semiquantitative Abschätzung des Prozentsatzes der Gesamtkarzinomfläche/Gesamtstanzzylinderfläche der am schwersten befallenen Stanze</xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="Prozentzahl">
+                <xs:annotation>
+                    <xs:documentation>natürliche Zahl (1-100) in %</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:positiveInteger">
+                        <xs:maxInclusive value="100"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="U">
+                <xs:annotation>
+                    <xs:documentation>Unbekannt</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>Unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="Modul_Prostata_patho_Typ">
+        <xs:complexContent>
+            <xs:restriction base="Modul_Prostata_Typ">
+                <xs:sequence>
+                    <xs:element name="GleasonScore" type="GleasonScore_Typ" minOccurs="0"/>
+                    <xs:element name="AnlassGleasonScore" type="AnlassGleasonScore_Typ" minOccurs="0"/>
+                    <xs:element name="DatumStanzen" type="Datum_Tag_genau_Typ" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Datum der Entnahme der Stanzen
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="AnzahlStanzen" type="AnzahlStanzen_Typ" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Anzahl der entnommenen Stanzen
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="AnzahlPosStanzen" type="AnzahlStanzen_Typ" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Anzahl der positiven Stanzen
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="CaBefallStanze" type="CaBefallStanze_Typ" minOccurs="0"/>
+                </xs:sequence>
+            </xs:restriction>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="Modul_Prostata_Typ">
+        <xs:sequence>
+            <xs:element name="GleasonScore" type="GleasonScore_Typ" minOccurs="0"/>
+            <xs:element name="AnlassGleasonScore" type="AnlassGleasonScore_Typ" minOccurs="0"/>
+            <xs:element name="DatumStanzen" type="Datum_Tag_genau_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Datum der Entnahme der Stanzen
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="AnzahlStanzen" type="AnzahlStanzen_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Anzahl der entnommenen Stanzen
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="AnzahlPosStanzen" type="AnzahlStanzen_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Anzahl der positiven Stanzen
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="CaBefallStanze" type="CaBefallStanze_Typ" minOccurs="0"/>
+            <xs:element name="PSA" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Aktuell relevanter PSA-Wert als Fließkommazahl in ng/ml (max. 3 Dezimalstellen nach dem Dezimalpunkt)
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:decimal">
+                        <xs:fractionDigits value="3"/>
+                        <xs:minInclusive value="0"/>
+                        <xs:maxExclusive value="100000"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="DatumPSA" type="Datum_Tag_genau_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Datum der Blutentnahme zur PSA-Bestimmung
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="KomplPostOP_ClavienDindo" type="JNU_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Komplikation der Clavien-Dindo Grade III oder IV innerhalb der ersten 6 Monate nach Radikaler Prostatektomie
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="Sicherheitsabstand_Primaertumor_Typ">
+        <xs:annotation>
+            <xs:documentation>
+                Minimaler Sicherheitsabstand zum Primärtumor in Millimeter.
+                Ausprägungen:
+                -1 = nicht zu beurteilen
+                0 = kein Abstand
+                n = Abstand in mm (natürliche Zahl)
+                Hinweis:
+                Es ist der endgültige kumulative Sicherheitsabstand, d. h. nach definitiver operativer Versorgung zu verwenden.
+                Es soll die sichere Untergrenze angegeben werden.
+                Ein Abstand von 0 entspricht lokal R1 oder R2, bzw. randständig.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:integer">
+            <xs:minInclusive value="-1"/>
+            <xs:maxInclusive value="150"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Tumordicke_Typ">
+        <xs:annotation>
+            <xs:documentation>Tumordicke in mm.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:decimal">
+            <xs:fractionDigits value="1"/>
+            <xs:minInclusive value="0.1"/>
+            <xs:maxInclusive value="99.0"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="Modul_Malignes_Melanom_patho_Typ">
+        <xs:complexContent>
+            <xs:restriction base="Modul_Malignes_Melanom_Typ">
+                <xs:sequence>
+                    <xs:element name="Sicherheitsabstand_Primaertumor" type="Sicherheitsabstand_Primaertumor_Typ" minOccurs="0"/>
+                    <xs:element name="Tumordicke" type="Tumordicke_Typ" minOccurs="0"/>
+                    <xs:element name="Ulzeration" type="JNU_Typ" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Pathologisches Kriterium der Ulzeration erfüllt.
+                                Hinweis:
+                                Dieses Feld soll nur im TNM-Stadium pT1b angegeben werden,
+                                da dieses Stadium mit und ohne Ulzerationen definiert ist.
+                                (Quelle: TNM-Klassifikation, 8. Auflage 2020, S. 188).
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+            </xs:restriction>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="Modul_Malignes_Melanom_Typ">
+        <xs:sequence>
+            <xs:element name="Sicherheitsabstand_Primaertumor" type="Sicherheitsabstand_Primaertumor_Typ" minOccurs="0"/>
+            <xs:element name="Tumordicke" type="Tumordicke_Typ" minOccurs="0"/>
+            <xs:element name="LDH" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        LDH-Wert in Unit/Liter (U/l).
+                        Hinweis:
+                        Für die Umrechung von Katal/l nach Unit/l gilt:
+                        1µkat/l = 60 U/l
+                        100 U/l = 1.67 µkat/l.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:integer">
+                        <xs:minInclusive value="1"/>
+                        <xs:maxInclusive value="10000"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Ulzeration" type="JNU_Typ" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Modul_DKKR_Typ">
+        <xs:sequence>
+            <xs:element name="Meldung_EW_DKKR" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Stand der schriftlich vorliegenden Einwilligung (EW) zur Meldung, 1x pro Patient und bei Änderung des Einwilligungsstatus</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="1">
+                            <xs:annotation>
+                                <xs:documentation>EW liegt von/vom Sorgeberechtigten vor</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="2">
+                            <xs:annotation>
+                                <xs:documentation>EW wurde verweigert</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="3">
+                            <xs:annotation>
+                                <xs:documentation>EW wird bald nachgereicht</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="5">
+                            <xs:annotation>
+                                <xs:documentation>EW liegt vom Patienten selbst vor</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Meldung_Austausch" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Informierung Patient*in/Sorgeberechtigte vom Datenaustausch DKKR-Landeskrebsregister, 1x pro Patient und bei Änderung des Einwilligungsstatus</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="1">
+                            <xs:annotation>
+                                <xs:documentation>Patientin/Patient/Eltern/Sorgeberechtige wurde/n informiert und hat/haben widersprochen d.h. verweigern den Datenaustausch/die Datenweitergabe an das Landeskrebsregister</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="2">
+                            <xs:annotation>
+                                <xs:documentation>Patientin/Patient/Eltern/Sorgeberechtige wurde/n vom Datenaustausch mit Landeskrebsregister informiert und hat/haben nicht widersprochen</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="9">
+                            <xs:annotation>
+                                <xs:documentation>Die Informierung unterblieb</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="GPOH_Therapiestudienpatient" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Therapiestudien, Therapieoptimierungsstudien, Therapieprotokolle oder tumorspezifische Register unter dem Dach der GPOH.
+                        "ja": Patient kommt für eine Studie/Register in Frage bzw wurde der Studien-/Registerleitung mitgeteilt, bei jedem Meldeanlass</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice>
+                        <xs:element name="unbekannt_nein">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="0">
+                                        <xs:annotation>
+                                            <xs:documentation>keine Angabe</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="2">
+                                        <xs:annotation>
+                                            <xs:documentation>nein</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="Menge_GPOH_Therapiestudien">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="Therapiestudie" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="GPOH_Therapiestudienname" type="Freitext255E_Typ"/>
+                                                <xs:element name="GPOH_Therapiestudiennummer" type="Freitext255_Typ" minOccurs="0"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Menge_Syndrome" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Syndrom_oder_sonstiges" maxOccurs="unbounded" type="Freitext255E_Typ"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="Hormonrezeptor_Typ">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="P">
+                <xs:annotation>
+                    <xs:documentation>Positiv</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="N">
+                <xs:annotation>
+                    <xs:documentation>Negativ</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="U">
+                <xs:annotation>
+                    <xs:documentation>Unbekannt</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Seitenlokalisation_Typ">
+        <xs:annotation>
+            <xs:documentation>Organspezifische Angabe der betroffenen Seite</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="L">
+                <xs:annotation>
+                    <xs:documentation>Links</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="R">
+                <xs:annotation>
+                    <xs:documentation>Rechts</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="B">
+                <xs:annotation>
+                    <xs:documentation>Beidseitig (bei bestimmten Tumoren 2 Meldungen angeben)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="M">
+                <xs:annotation>
+                    <xs:documentation>Mittellinie/mittig</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="U">
+                <xs:annotation>
+                    <xs:documentation>Unbekannt</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="T">
+                <xs:annotation>
+                    <xs:documentation>Trifft nicht zu (Seitenangabe nicht sinnvoll, einschließlich Systemerkrankungen)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Allgemeiner_Leistungszustand_Typ">
+        <xs:annotation>
+            <xs:documentation>
+                ECOG oder Karnofsky
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="0">
+                <xs:annotation>
+                    <xs:documentation>Normale, uneingeschränkte Aktivität wie vor der Erkrankung (90 - 100 % nach Karnofsky)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="1">
+                <xs:annotation>
+                    <xs:documentation>Einschränkung bei körperlicher Anstrengung, aber gehfähig; leichte körperliche Arbeit bzw. Arbeit im Sitzen (z.B. leichte Hausarbeit oder Büroarbeit) möglich (70 - 80 % nach Karnofsky)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2">
+                <xs:annotation>
+                    <xs:documentation>Gehfähig, Selbstversorgung möglich, aber nicht arbeitsfähig; kann mehr als 50% der Wachzeit aufstehen (50 - 60 % nach Karnofsky)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3">
+                <xs:annotation>
+                    <xs:documentation>Nur begrenzte Selbstversorgung möglich; ist 50% oder mehr der Wachzeit an Bett oder Stuhl gebunden (30 - 40 % nach Karnofsky)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4">
+                <xs:annotation>
+                    <xs:documentation>Völlig pflegebedürftig, keinerlei Selbstversorgung möglich; völlig an Bett oder Stuhl gebunden (10 - 20% nach Karnofsky) </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="U">
+                <xs:annotation>
+                    <xs:documentation>Unbekannt</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="10%"/>
+            <xs:enumeration value="20%"/>
+            <xs:enumeration value="30%"/>
+            <xs:enumeration value="40%"/>
+            <xs:enumeration value="50%"/>
+            <xs:enumeration value="60%"/>
+            <xs:enumeration value="70%"/>
+            <xs:enumeration value="80%"/>
+            <xs:enumeration value="90%"/>
+            <xs:enumeration value="100%"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Zahl_3stellig_Typ">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d(\d)?(\d)?|U"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="Datum_NU_Typ">
+        <xs:choice>
+            <xs:element name="Datum" type="Datum_Tag_genau_Typ"/>
+            <xs:element name="NU">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="N">
+                            <xs:annotation>
+                                <xs:documentation>Nein</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>Unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="Datum_N_Typ">
+        <xs:choice>
+            <xs:element name="Datum" type="Datum_Tag_genau_Typ"/>
+            <xs:element name="N" type="xs:string" fixed="N"/>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="TNM_Typ">
+        <xs:sequence>
+            <xs:element name="Datum" type="Datum_Tag_genau_Typ" minOccurs="0"/>
+            <xs:element name="Version" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="6">
+                            <xs:annotation>
+                                <xs:documentation>6. Auflage</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="7">
+                            <xs:annotation>
+                                <xs:documentation>7. Auflage</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="8">
+                            <xs:annotation>
+                                <xs:documentation>8. Auflage</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="y_Symbol" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Das Weglassen des Tags bedeutet, dass die Klassifikation vor einer initialen multimodaler Therapie erfolgte (oder keine solche stattgefunden hat).</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="y">
+                            <xs:annotation>
+                                <xs:documentation>Klassifikation erfolgte während oder nach initialer multimodaler Therapie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="r_Symbol" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Das Weglassen des Tags bedeutet, dass die Klassifikation im Rahmen der Primärdiagnostik/-therapie erfolgte.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="r">
+                            <xs:annotation>
+                                <xs:documentation>Klassifikation erfolgte zur Beurteilung eines Rezidivs</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="a_Symbol" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Das Weglassen des Tags bedeutet, dass die Klassifikation klinisch und/oder pathologisch erfolgte.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="a">
+                            <xs:annotation>
+                                <xs:documentation>Die Klassifikation durch eine Autopsie festgelegt.</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="c_p_u_Praefix_T" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Das Weglassen des Prefix wird als "c" interpretiert</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="c">
+                            <xs:annotation>
+                                <xs:documentation>Kategorie wurde durch klinische Angaben festgestellt, bzw. erfüllt die Kriterien für p nicht</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="p">
+                            <xs:annotation>
+                                <xs:documentation>Feststellung der Kategorie erfolgte durch eine pathohistologische Untersuchung, mit der auch der höchste Grad der jeweiligen Kategorie hätte festgestellt werden können </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="u">
+                            <xs:annotation>
+                                <xs:documentation>Feststellung mit Ultraschall (Unterkategorie von c mit besonderer diagnostischer Relevanz, z.B. beim Rektumkarzinom)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="T" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="Freitext30_Typ">
+                        <xs:pattern value="(is.*)|([a01234X].*)"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="m_Symbol" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:pattern value="[m](,is){0,1}|(is)|[2-9](,is){0,1}|[1-9][0-9]{1,2}(,is){0,1}"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="c_p_u_Praefix_N" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Das Weglassen des Prefix wird als "c" interpretiert</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="c">
+                            <xs:annotation>
+                                <xs:documentation>Kategorie wurde durch klinische Angaben festgestellt, bzw. erfüllt die Kriterien für p nicht</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="p">
+                            <xs:annotation>
+                                <xs:documentation> Feststellung der Kategorie erfolgte durch eine pathohistologische Untersuchung, mit der auch der höchste Grad der jeweiligen Kategorie hätte festgestellt werden können
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="u">
+                            <xs:annotation>
+                                <xs:documentation>Feststellung mit Ultraschall (Unterkategorie von c mit besonderer diagnostischer Relevanz, z.B. beim Rektumkarzinom)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="N" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="Freitext30_Typ">
+                        <xs:pattern value="[0123X].*"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="c_p_u_Praefix_M" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Das Weglassen des Prefix wird als "c" interpretiert</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="c">
+                            <xs:annotation>
+                                <xs:documentation>Kategorie wurde durch klinische Angaben festgestellt, bzw. erfüllt die Kriterien für p nicht</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="p">
+                            <xs:annotation>
+                                <xs:documentation>Feststellung der Kategorie erfolgte durch eine pathohistologische Untersuchung, mit der auch der höchste Grad der jeweiligen Kategorie hätte festgestellt werden können </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="u">
+                            <xs:annotation>
+                                <xs:documentation>Feststellung mit Ultraschall (Unterkategorie von c mit besonderer diagnostischer Relevanz, z.B. beim Rektumkarzinom)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="M" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="Freitext30_Typ">
+                        <xs:pattern value="[01X].*"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="L" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Lymphgefäßinvasion. Erfolgt im Allgemeinen im Rahmen eines "pTNM".</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="LX">
+                            <xs:annotation>
+                                <xs:documentation>Lymphgefäßinvasion kann nicht beurteilt werden</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="L0">
+                            <xs:annotation>
+                                <xs:documentation>Keine Lymphgefäßinvasion</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="L1">
+                            <xs:annotation>
+                                <xs:documentation>Lymphgefäßinvasion</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="V" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Veneninvasion. Erfolgt im Allgemeinen im Rahmen eines "pTNM".</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="VX">
+                            <xs:annotation>
+                                <xs:documentation>Veneninvasion kann nicht beurteilt werden</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="V0">
+                            <xs:annotation>
+                                <xs:documentation>Keine Veneninvasion</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="V1">
+                            <xs:annotation>
+                                <xs:documentation>Mikroskopische Veneninvasion</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="V2">
+                            <xs:annotation>
+                                <xs:documentation>Makroskopische Veneninvasion</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Pn" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Perineuralinvasion. Erfolgt im Allgemeinen im Rahmen eines "pTNM".</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="PnX">
+                            <xs:annotation>
+                                <xs:documentation>Perineurale Invasion kann nicht beurteilt werden</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="Pn0">
+                            <xs:annotation>
+                                <xs:documentation>Keine perineurale Invasion</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="Pn1">
+                            <xs:annotation>
+                                <xs:documentation>Perineurale Invasion</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="S" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+
+                        Serumtumormarker
+                        SX = Werte der Serumtumormarker nicht verfügbar oder entsprechende Untersuchungen nicht vorgenommen
+                        S0 = Serumtumormarker innerhalb der normalen Grenzen
+                        S1–S3 = Wenigstens einer der Serumtumormarker erhöht
+                        LDH					HCG					AFP
+                        S1			&lt; 1,5N		und		&lt; 5000		und		&lt; 1000
+                        S2			1,5-10N		oder	5000-50000  oder	1000-10000
+                        S3			&gt; 10 N		oder	&gt; 50000		oder	&gt; 10000
+                        N = obere Grenze des Normalwertes
+                        (Quelle: TNM-Klassifikation, 8. Auflage 2020, S.252)
+
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="SX"/>
+                        <xs:enumeration value="S0"/>
+                        <xs:enumeration value="S1"/>
+                        <xs:enumeration value="S2"/>
+                        <xs:enumeration value="S3"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="UICC_Stadium" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="okk">
+                            <xs:annotation>
+                                <xs:documentation>okk</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="0">
+                            <xs:annotation>
+                                <xs:documentation>0</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="0a">
+                            <xs:annotation>
+                                <xs:documentation>0a</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="0is">
+                            <xs:annotation>
+                                <xs:documentation>0is</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="I">
+                            <xs:annotation>
+                                <xs:documentation>I</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IA">
+                            <xs:annotation>
+                                <xs:documentation>IA</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IA1">
+                            <xs:annotation>
+                                <xs:documentation>IA1</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IA2">
+                            <xs:annotation>
+                                <xs:documentation>IA2</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IA3">
+                            <xs:annotation>
+                                <xs:documentation>IA3</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IB">
+                            <xs:annotation>
+                                <xs:documentation>IB</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IB1">
+                            <xs:annotation>
+                                <xs:documentation>IB1</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IB2">
+                            <xs:annotation>
+                                <xs:documentation>IB2</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IC">
+                            <xs:annotation>
+                                <xs:documentation>IC</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="II">
+                            <xs:annotation>
+                                <xs:documentation>II</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IIA">
+                            <xs:annotation>
+                                <xs:documentation>IIA</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IIA1">
+                            <xs:annotation>
+                                <xs:documentation>IIA1</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IIA2">
+                            <xs:annotation>
+                                <xs:documentation>IIA2</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IIB">
+                            <xs:annotation>
+                                <xs:documentation>IIB</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IIC">
+                            <xs:annotation>
+                                <xs:documentation>IIC</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="III">
+                            <xs:annotation>
+                                <xs:documentation>III</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IIIA">
+                            <xs:annotation>
+                                <xs:documentation>IIIA</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IIIA1">
+                            <xs:annotation>
+                                <xs:documentation>IIIA1</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IIIA2">
+                            <xs:annotation>
+                                <xs:documentation>IIIA2</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IIIB">
+                            <xs:annotation>
+                                <xs:documentation>IIIB</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IIIC">
+                            <xs:annotation>
+                                <xs:documentation>IIIC</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IIIC1">
+                            <xs:annotation>
+                                <xs:documentation>IIIC1</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IIIC2">
+                            <xs:annotation>
+                                <xs:documentation>IIIC2</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IIID">
+                            <xs:annotation>
+                                <xs:documentation>IIID</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IS">
+                            <xs:annotation>
+                                <xs:documentation>IS</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IV">
+                            <xs:annotation>
+                                <xs:documentation>IV</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IVA">
+                            <xs:annotation>
+                                <xs:documentation>IVA</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IVA1">
+                            <xs:annotation>
+                                <xs:documentation>IVA1</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IVA2">
+                            <xs:annotation>
+                                <xs:documentation>IVA2</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IVB">
+                            <xs:annotation>
+                                <xs:documentation>IVB</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IVC">
+                            <xs:annotation>
+                                <xs:documentation>IVC</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="ID" type="FreitextID_Typ" use="optional"/>
+    </xs:complexType>
+    <xs:simpleType name="ISO3166Alpha2Code_Typ">
+        <xs:annotation>
+            <xs:documentation>Die Codes werden als regulärer Ausdruck zweier Großbuchstaben implementiert, um nicht bei Änderungen eine neue Schemaversion herausgeben zu müssen.
+                Die übermittelten Codes müssen https://www.iso.org/iso-3166-country-codes.html entsprechen.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z]{2}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Freitext30_Typ">
+        <xs:restriction base="datatypeCtrimmed">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="30"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FreitextID_Typ">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="50"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Freitext255_Typ">
+        <xs:restriction base="datatypeCtrimmed">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Freitext255E_Typ">
+        <xs:restriction base="datatypeE">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Diagnosetext_Typ">
+        <xs:restriction base="datatypeC">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="1000"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FreitextAnmerkung_Typ">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="2000"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="FreitextCLOB_Typ">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="Namenstring255_Typ">
+        <xs:restriction base="datatypeAtrimmed">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Adressstring255_Typ">
+        <xs:restriction base="datatypeBtrimmed">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Adressstring10_Typ">
+        <xs:restriction base="datatypeBtrimmed">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="10"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="Topographie_ICD_O_Typ">
+        <xs:sequence>
+            <xs:element name="Code">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:pattern value="C\d\d\.\d(\d)?"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Version">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="31">
+                            <xs:annotation>
+                                <xs:documentation>ICD-O-3, 2003</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="32">
+                            <xs:annotation>
+                                <xs:documentation>ICD-O-3, 1. Revision 2014</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="33">
+                            <xs:annotation>
+                                <xs:documentation>ICD-O-3, 2. Revision 2019</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Versichertendaten_GKV_Typ">
+        <xs:sequence>
+            <xs:element name="IKNR">
+                <xs:simpleType>
+                    <xs:restriction base="Ziffern9_Typ">
+                        <xs:pattern value="10\d{7}"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="GKV_Versichertennummer">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:pattern value="[A-Z]\d{9}"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Versichertendaten_PKV_Typ">
+        <xs:sequence>
+            <xs:element name="IKNR">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:pattern value="16\d{7}|950\d{6}"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="PKV_Versichertennummer" type="Freitext255_Typ" minOccurs="0"/>
+            <xs:element name="Beihilfetraeger" type="Freitext255_Typ" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Versichertendaten_Sonstige_Typ">
+        <xs:annotation>
+            <xs:documentation>
+                Diese Felder sind nur dann zu nutzen, wenn keine gültigen Angaben zu GKV oder PKV vorliegen.
+                Außerdem bildet dieser Typ einige Spezialfälle ab, bei denen eine Kassen-IKNR zwar mit 10 beginnt,
+                die Versicherten jedoch keine eGK-Nummer bekommen (aus dem Bereich Post, Polizei, ...)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="Ersatzkode">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="970000011">
+                                <xs:annotation>
+                                    <xs:documentation>Selbstzahler</xs:documentation>
+                                </xs:annotation>
+                            </xs:enumeration>
+                            <xs:enumeration value="970001001">
+                                <xs:annotation>
+                                    <xs:documentation>Kostenträger ohne IK-Nummer (z.B. Gefängnisinsassen, ...)</xs:documentation>
+                                </xs:annotation>
+                            </xs:enumeration>
+                            <xs:enumeration value="970100001">
+                                <xs:annotation>
+                                    <xs:documentation>Asylbewerber</xs:documentation>
+                                </xs:annotation>
+                            </xs:enumeration>
+                            <xs:enumeration value="970000022">
+                                <xs:annotation>
+                                    <xs:documentation>Privatversichert, Kasse unbekannt</xs:documentation>
+                                </xs:annotation>
+                            </xs:enumeration>
+                            <xs:enumeration value="970000099">
+                                <xs:annotation>
+                                    <xs:documentation>Keine Angabe zum Kostenträger</xs:documentation>
+                                </xs:annotation>
+                            </xs:enumeration>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="IKNR" minOccurs="0">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:pattern value="\d{9}"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="KrankenkassenName" type="Freitext255_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Bei unsicheren Angaben kann ersatzweise/zusätzlich die Krankenkassen im Freitext angegeben werden</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Versichertennummer" type="Freitext255_Typ" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="oBDS_Zielgebiet2021_Typ">
+        <xs:annotation>
+            <xs:documentation>Zielgebietschlüssel nach oBDS 2021</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="1.1">
+                <xs:annotation>
+                    <xs:documentation>Ganzhirn (Neurokranium, inklusive Meningen)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="1.2">
+                <xs:annotation>
+                    <xs:documentation>Teilhirn (frontal/parietal/occipital/temporal/Kleinhirn)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="1.3">
+                <xs:annotation>
+                    <xs:documentation>Neuroachse/Rückenmark</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="1.4">
+                <xs:annotation>
+                    <xs:documentation>Hypophyse</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="1.5">
+                <xs:annotation>
+                    <xs:documentation>Hirn sonstiges</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.1">
+                <xs:annotation>
+                    <xs:documentation>Auge (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.2">
+                <xs:annotation>
+                    <xs:documentation>Nase/Nasennebenhöhle</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.3">
+                <xs:annotation>
+                    <xs:documentation>Mundhöhle inklusive Mundhöhlenvorhof</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.4">
+                <xs:annotation>
+                    <xs:documentation>Ohr (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.5">
+                <xs:annotation>
+                    <xs:documentation>Speicheldrüse (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.6">
+                <xs:annotation>
+                    <xs:documentation>Pharynx</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.7">
+                <xs:annotation>
+                    <xs:documentation>Nasopharynx</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.8">
+                <xs:annotation>
+                    <xs:documentation>Oropharynx</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.9">
+                <xs:annotation>
+                    <xs:documentation>Hypopharynx</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.10">
+                <xs:annotation>
+                    <xs:documentation>Larynx</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.11">
+                <xs:annotation>
+                    <xs:documentation>Schilddrüse</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.12">
+                <xs:annotation>
+                    <xs:documentation>Kopf-Hals sonstige</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.1">
+                <xs:annotation>
+                    <xs:documentation>Mamma als Ganzbrust (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.2">
+                <xs:annotation>
+                    <xs:documentation>Mamma als Teilbrust (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.3">
+                <xs:annotation>
+                    <xs:documentation>Thoraxwand, gegebenenfalls r, l</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.4">
+                <xs:annotation>
+                    <xs:documentation>Lunge (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.5">
+                <xs:annotation>
+                    <xs:documentation>Ösophagus</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.6">
+                <xs:annotation>
+                    <xs:documentation>Mediastinum (mediastinaler Lymphabfluss ist in Nummer 9 zu kodieren)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.7">
+                <xs:annotation>
+                    <xs:documentation>Thymus</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.8">
+                <xs:annotation>
+                    <xs:documentation>Thorax sonstige</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.1">
+                <xs:annotation>
+                    <xs:documentation>Magen</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.2">
+                <xs:annotation>
+                    <xs:documentation>Pankreas</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.3">
+                <xs:annotation>
+                    <xs:documentation>Leber, auch bei Teilbestrahlung</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.4">
+                <xs:annotation>
+                    <xs:documentation>Milz</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.5">
+                <xs:annotation>
+                    <xs:documentation>Niere (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.6">
+                <xs:annotation>
+                    <xs:documentation>Nebenniere (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.7">
+                <xs:annotation>
+                    <xs:documentation>Retroperitoneum (z. B. Sarkome)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.8">
+                <xs:annotation>
+                    <xs:documentation>Ureter (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.9">
+                <xs:annotation>
+                    <xs:documentation>Bauchwand (z. B. Sarkome)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.10">
+                <xs:annotation>
+                    <xs:documentation>Oberbauch</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.11">
+                <xs:annotation>
+                    <xs:documentation>Gallengänge</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.12">
+                <xs:annotation>
+                    <xs:documentation>Gallenblase</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.13">
+                <xs:annotation>
+                    <xs:documentation>Abdomen sonstige</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.1">
+                <xs:annotation>
+                    <xs:documentation>Rektum</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.2">
+                <xs:annotation>
+                    <xs:documentation>Analbereich</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.3">
+                <xs:annotation>
+                    <xs:documentation>Harnblase</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.4">
+                <xs:annotation>
+                    <xs:documentation>Prostata</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.5">
+                <xs:annotation>
+                    <xs:documentation>Hoden (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.6">
+                <xs:annotation>
+                    <xs:documentation>Penis</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.7">
+                <xs:annotation>
+                    <xs:documentation>Uterus</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.8">
+                <xs:annotation>
+                    <xs:documentation>Zervix</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.9">
+                <xs:annotation>
+                    <xs:documentation>Vulva</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.10">
+                <xs:annotation>
+                    <xs:documentation>Vagina</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.11">
+                <xs:annotation>
+                    <xs:documentation>Beckenwand</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.12">
+                <xs:annotation>
+                    <xs:documentation>Becken sonstige</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.1">
+                <xs:annotation>
+                    <xs:documentation>Schädel</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.2">
+                <xs:annotation>
+                    <xs:documentation>Schädelbasis</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.3">
+                <xs:annotation>
+                    <xs:documentation>Orbita (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.4">
+                <xs:annotation>
+                    <xs:documentation>Halswirbelsäule</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.5">
+                <xs:annotation>
+                    <xs:documentation>Brustwirbelsäule</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.6">
+                <xs:annotation>
+                    <xs:documentation>Lendenwirbelsäule</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.7">
+                <xs:annotation>
+                    <xs:documentation>Sacrum/Coccygeum</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.8">
+                <xs:annotation>
+                    <xs:documentation>Rippen (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.9">
+                <xs:annotation>
+                    <xs:documentation>Sternum</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.10">
+                <xs:annotation>
+                    <xs:documentation>Schulter (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.11">
+                <xs:annotation>
+                    <xs:documentation>Oberarm (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.12">
+                <xs:annotation>
+                    <xs:documentation>Unterarm (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.13">
+                <xs:annotation>
+                    <xs:documentation>Hand (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.14">
+                <xs:annotation>
+                    <xs:documentation>Becken (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.15">
+                <xs:annotation>
+                    <xs:documentation>Hüfte (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.16">
+                <xs:annotation>
+                    <xs:documentation>Oberschenkel (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.17">
+                <xs:annotation>
+                    <xs:documentation>Unterschenkel (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.18">
+                <xs:annotation>
+                    <xs:documentation>Fuß (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.19">
+                <xs:annotation>
+                    <xs:documentation>Knochen sonstige</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="7.1">
+                <xs:annotation>
+                    <xs:documentation>Kopf, Gesicht, Hals</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="7.2">
+                <xs:annotation>
+                    <xs:documentation>obere Extremität inklusive Schulter (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="7.3">
+                <xs:annotation>
+                    <xs:documentation>untere Extremität und Hüfte (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="7.4">
+                <xs:annotation>
+                    <xs:documentation>Thorax</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="7.5">
+                <xs:annotation>
+                    <xs:documentation>Abdomen</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="7.6">
+                <xs:annotation>
+                    <xs:documentation>Becken</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="7.7">
+                <xs:annotation>
+                    <xs:documentation>Stammes o. n. A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="7.8">
+                <xs:annotation>
+                    <xs:documentation>mehrere Bereiche überlappend</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="7.9">
+                <xs:annotation>
+                    <xs:documentation>sonstige Weichteile o. n. A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="8.1">
+                <xs:annotation>
+                    <xs:documentation>Ganzhaut</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="8.2">
+                <xs:annotation>
+                    <xs:documentation>Teilbereiche</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.1">
+                <xs:annotation>
+                    <xs:documentation>Cervikale Lymphknoten (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.2">
+                <xs:annotation>
+                    <xs:documentation>Supra-/infraclavikuläre Lymphknoten (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.3">
+                <xs:annotation>
+                    <xs:documentation>Axilläre Lymphknoten (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.4">
+                <xs:annotation>
+                    <xs:documentation>Retrosternale/sternale/Mammaria interna Lymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.5">
+                <xs:annotation>
+                    <xs:documentation>Mediastinale Lymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.6">
+                <xs:annotation>
+                    <xs:documentation>Hiläre Lymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.7">
+                <xs:annotation>
+                    <xs:documentation>Intraabdominale Lymphknoten (z. B. subphrenisch, perigastrisch, peripankreatisch, Leber-, Milzhilus)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.8">
+                <xs:annotation>
+                    <xs:documentation>Paraaortale/paracavale Lymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.9">
+                <xs:annotation>
+                    <xs:documentation>Retroperitoneale Lymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.10">
+                <xs:annotation>
+                    <xs:documentation>Beckenlymphabfluss (r, l) (Iliakal commun, extern, intern, obturatorisch, präsakral)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.11">
+                <xs:annotation>
+                    <xs:documentation>Inguinale Lymphknoten (r, l)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.12">
+                <xs:annotation>
+                    <xs:documentation>Involved Node</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.13">
+                <xs:annotation>
+                    <xs:documentation>Involved Site</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.14">
+                <xs:annotation>
+                    <xs:documentation>Involved Field</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="9.15">
+                <xs:annotation>
+                    <xs:documentation>Sonstige Lymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="10.1">
+                <xs:annotation>
+                    <xs:documentation>Ganzkörperbestrahlung bei allogener Stammzelltransplantation</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="10.2">
+                <xs:annotation>
+                    <xs:documentation>operative Zugangswege</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="10.3">
+                <xs:annotation>
+                    <xs:documentation>Sonstige, nicht genannte Zielgebiete</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="oBDS_Zielgebiet2014_Typ">
+        <xs:annotation>
+            <xs:documentation>
+                Zielgebietschlüssel nach oBDS 2014
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="1.">
+                <xs:annotation>
+                    <xs:documentation>ZNS</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="1.1.">
+                <xs:annotation>
+                    <xs:documentation>Ganzhirn</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="1.2.">
+                <xs:annotation>
+                    <xs:documentation>Teilhirn</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="1.3.">
+                <xs:annotation>
+                    <xs:documentation>Neuroachse</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.">
+                <xs:annotation>
+                    <xs:documentation>Kopf-Hals</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.+">
+                <xs:annotation>
+                    <xs:documentation>Kopf-Hals mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.-">
+                <xs:annotation>
+                    <xs:documentation>Kopf-Hals ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.1.">
+                <xs:annotation>
+                    <xs:documentation>Orbita, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.1.+">
+                <xs:annotation>
+                    <xs:documentation>Orbita mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.1.-">
+                <xs:annotation>
+                    <xs:documentation>Orbita ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.2.">
+                <xs:annotation>
+                    <xs:documentation>Nase/ Nasennebenhöhle, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.2.+">
+                <xs:annotation>
+                    <xs:documentation>Nase/ Nasennebenhöhle mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.2.-">
+                <xs:annotation>
+                    <xs:documentation>Nase/ Nasennebenhöhle ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.3.">
+                <xs:annotation>
+                    <xs:documentation>Mundhöhle, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.3.+">
+                <xs:annotation>
+                    <xs:documentation>Mundhöhle mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.3.-">
+                <xs:annotation>
+                    <xs:documentation>Mundhöhle ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.4.">
+                <xs:annotation>
+                    <xs:documentation>Ohr, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.4.+">
+                <xs:annotation>
+                    <xs:documentation>Ohr mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.4.-">
+                <xs:annotation>
+                    <xs:documentation>Ohr ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.5.">
+                <xs:annotation>
+                    <xs:documentation>Speicheldrüse, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.5.+">
+                <xs:annotation>
+                    <xs:documentation>Speicheldrüse mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.5.-">
+                <xs:annotation>
+                    <xs:documentation>Speicheldrüse ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.6.">
+                <xs:annotation>
+                    <xs:documentation>Pharynx, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.6.+">
+                <xs:annotation>
+                    <xs:documentation>Pharynx mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.6.-">
+                <xs:annotation>
+                    <xs:documentation>Pharynx ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.7.">
+                <xs:annotation>
+                    <xs:documentation>Larynx, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.7.+">
+                <xs:annotation>
+                    <xs:documentation>Larynx mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.7.-">
+                <xs:annotation>
+                    <xs:documentation>Larynx ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.8.">
+                <xs:annotation>
+                    <xs:documentation>Schilddrüse, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.8.+">
+                <xs:annotation>
+                    <xs:documentation>Schilddrüse mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.8.-">
+                <xs:annotation>
+                    <xs:documentation>Schilddrüse ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="2.9.">
+                <xs:annotation>
+                    <xs:documentation>Halslymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.">
+                <xs:annotation>
+                    <xs:documentation>Thorax</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.+">
+                <xs:annotation>
+                    <xs:documentation>Thorax mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.-">
+                <xs:annotation>
+                    <xs:documentation>Thorax ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.1.">
+                <xs:annotation>
+                    <xs:documentation>Mamma als Ganzbrust, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.1.+">
+                <xs:annotation>
+                    <xs:documentation>Mamma als Ganzbrust mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.1.-">
+                <xs:annotation>
+                    <xs:documentation>Mamma als Ganzbrust ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.2.">
+                <xs:annotation>
+                    <xs:documentation>Mamma als Teilbrust, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.2.+">
+                <xs:annotation>
+                    <xs:documentation>Mamma als Teilbrust mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.2.-">
+                <xs:annotation>
+                    <xs:documentation>Mamma als Teilbrust ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.3.">
+                <xs:annotation>
+                    <xs:documentation>Brustwand</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.3.+">
+                <xs:annotation>
+                    <xs:documentation>Brustwand mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.3.-">
+                <xs:annotation>
+                    <xs:documentation>Brustwand ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.4.">
+                <xs:annotation>
+                    <xs:documentation>Lunge, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.4.+">
+                <xs:annotation>
+                    <xs:documentation>Lunge mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.4.-">
+                <xs:annotation>
+                    <xs:documentation>Lunge ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.5.">
+                <xs:annotation>
+                    <xs:documentation>Ösophagus, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.5.+">
+                <xs:annotation>
+                    <xs:documentation>Ösophagus mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.5.-">
+                <xs:annotation>
+                    <xs:documentation>Ösophagus ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.6.">
+                <xs:annotation>
+                    <xs:documentation>Thymus, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.6.+">
+                <xs:annotation>
+                    <xs:documentation>Thymus mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.6.-">
+                <xs:annotation>
+                    <xs:documentation>Thymus ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3.7.">
+                <xs:annotation>
+                    <xs:documentation>Mediastinale Lymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.">
+                <xs:annotation>
+                    <xs:documentation>Abdomen (ohne Becken)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.+">
+                <xs:annotation>
+                    <xs:documentation>Abdomen (ohne Becken) mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.-">
+                <xs:annotation>
+                    <xs:documentation>Abdomen (ohne Becken) ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.1.">
+                <xs:annotation>
+                    <xs:documentation>Magen, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.1.+">
+                <xs:annotation>
+                    <xs:documentation>Magen mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.1.-">
+                <xs:annotation>
+                    <xs:documentation>Magen ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.2.">
+                <xs:annotation>
+                    <xs:documentation>Pankreas, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.2.+">
+                <xs:annotation>
+                    <xs:documentation>Pankreas mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.2.-">
+                <xs:annotation>
+                    <xs:documentation>Pankreas ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.3.">
+                <xs:annotation>
+                    <xs:documentation>Leber, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.3.+">
+                <xs:annotation>
+                    <xs:documentation>Leber mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.3.-">
+                <xs:annotation>
+                    <xs:documentation>Leber ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.4.">
+                <xs:annotation>
+                    <xs:documentation>Milz, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.4.+">
+                <xs:annotation>
+                    <xs:documentation>Milz mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.4.-">
+                <xs:annotation>
+                    <xs:documentation>Milz ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.5.">
+                <xs:annotation>
+                    <xs:documentation>Niere, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.5.+">
+                <xs:annotation>
+                    <xs:documentation>Niere mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.5.-">
+                <xs:annotation>
+                    <xs:documentation>Niere ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.6.">
+                <xs:annotation>
+                    <xs:documentation>Nebenniere, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.6.+">
+                <xs:annotation>
+                    <xs:documentation>Nebenniere mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.6.-">
+                <xs:annotation>
+                    <xs:documentation>Nebenniere ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.7.">
+                <xs:annotation>
+                    <xs:documentation>Retroperitoneale Lymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.8.">
+                <xs:annotation>
+                    <xs:documentation>Retroperitoneum, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.8.+">
+                <xs:annotation>
+                    <xs:documentation>Retroperitoneum mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.8.-">
+                <xs:annotation>
+                    <xs:documentation>Retroperitoneum ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.9.">
+                <xs:annotation>
+                    <xs:documentation>Bauchwand, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.9.+">
+                <xs:annotation>
+                    <xs:documentation>Bauchwand mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="4.9.-">
+                <xs:annotation>
+                    <xs:documentation>Bauchwand ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.">
+                <xs:annotation>
+                    <xs:documentation>Becken</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.+">
+                <xs:annotation>
+                    <xs:documentation>Becken mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.-">
+                <xs:annotation>
+                    <xs:documentation>Becken ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.1.">
+                <xs:annotation>
+                    <xs:documentation>Rektum, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.1.+">
+                <xs:annotation>
+                    <xs:documentation>Rektum mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.1.-">
+                <xs:annotation>
+                    <xs:documentation>Rektum ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.2.">
+                <xs:annotation>
+                    <xs:documentation>Analbereich, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.2.-">
+                <xs:annotation>
+                    <xs:documentation>Analbereich ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.2.+">
+                <xs:annotation>
+                    <xs:documentation>Analbereich mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.3.">
+                <xs:annotation>
+                    <xs:documentation>Harnblase, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.3.-">
+                <xs:annotation>
+                    <xs:documentation>Harnblase ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.3.+">
+                <xs:annotation>
+                    <xs:documentation>Harnblase mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.4.">
+                <xs:annotation>
+                    <xs:documentation>Prostata, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.4.+">
+                <xs:annotation>
+                    <xs:documentation>Prostata mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.4.-">
+                <xs:annotation>
+                    <xs:documentation>Prostata ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.5.">
+                <xs:annotation>
+                    <xs:documentation>Hoden, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.5.+">
+                <xs:annotation>
+                    <xs:documentation>Hoden mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.5.-">
+                <xs:annotation>
+                    <xs:documentation>Hoden ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.6.">
+                <xs:annotation>
+                    <xs:documentation>Penis, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.6.+">
+                <xs:annotation>
+                    <xs:documentation>Penis mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.6.-">
+                <xs:annotation>
+                    <xs:documentation>Penis ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.7.">
+                <xs:annotation>
+                    <xs:documentation>Uterus und Zervix, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.7.+">
+                <xs:annotation>
+                    <xs:documentation>Uterus und Zervix mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.7.2.-">
+                <xs:annotation>
+                    <xs:documentation>Zervix ohne Lymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.7.2.+">
+                <xs:annotation>
+                    <xs:documentation>Zervix mit Lymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.7.2.">
+                <xs:annotation>
+                    <xs:documentation>Zervix</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.7.1.-">
+                <xs:annotation>
+                    <xs:documentation>Uterus ohne Lymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.7.1.+">
+                <xs:annotation>
+                    <xs:documentation>Uterus mit Lymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.7.1.">
+                <xs:annotation>
+                    <xs:documentation>Uterus</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.7.-">
+                <xs:annotation>
+                    <xs:documentation>Uterus und Zervix ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.8.">
+                <xs:annotation>
+                    <xs:documentation>Ovar, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.8.-">
+                <xs:annotation>
+                    <xs:documentation>Ovar ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.8.+">
+                <xs:annotation>
+                    <xs:documentation>Ovar mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.9.">
+                <xs:annotation>
+                    <xs:documentation>Vulva, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.9.-">
+                <xs:annotation>
+                    <xs:documentation>Vulva ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.9.+">
+                <xs:annotation>
+                    <xs:documentation>Vulva mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.10.">
+                <xs:annotation>
+                    <xs:documentation>Vagina, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.10.+">
+                <xs:annotation>
+                    <xs:documentation>Vagina mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.10.-">
+                <xs:annotation>
+                    <xs:documentation>Vagina ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.11.">
+                <xs:annotation>
+                    <xs:documentation>Beckenwand, o.n.A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.11.+">
+                <xs:annotation>
+                    <xs:documentation>Beckenwand mit Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.11.-">
+                <xs:annotation>
+                    <xs:documentation>Beckenwand ohne Lk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="5.12.">
+                <xs:annotation>
+                    <xs:documentation>Beckenlymphkn. (ohne Primtu.)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.">
+                <xs:annotation>
+                    <xs:documentation>Stütz-/Bewegungsapparat</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.1.">
+                <xs:annotation>
+                    <xs:documentation>Schädelknochen</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.2.">
+                <xs:annotation>
+                    <xs:documentation>Rippen</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.3.">
+                <xs:annotation>
+                    <xs:documentation>Sternum</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.4.">
+                <xs:annotation>
+                    <xs:documentation>HWS</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.5.">
+                <xs:annotation>
+                    <xs:documentation>BWS</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.6.">
+                <xs:annotation>
+                    <xs:documentation>LWS</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.7.">
+                <xs:annotation>
+                    <xs:documentation>knöchernes Becken</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.8.">
+                <xs:annotation>
+                    <xs:documentation>Hüfte</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.9.">
+                <xs:annotation>
+                    <xs:documentation>Achsel</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.10.">
+                <xs:annotation>
+                    <xs:documentation>Oberarm</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.11.">
+                <xs:annotation>
+                    <xs:documentation>Unterarm</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.12.">
+                <xs:annotation>
+                    <xs:documentation>Hand</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.13.">
+                <xs:annotation>
+                    <xs:documentation>Leiste</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.14.">
+                <xs:annotation>
+                    <xs:documentation>Oberschenkel</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.15.">
+                <xs:annotation>
+                    <xs:documentation>Unterschenkel</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="6.16.">
+                <xs:annotation>
+                    <xs:documentation>Fuß</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="7.">
+                <xs:annotation>
+                    <xs:documentation>Haut</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="7.+">
+                <xs:annotation>
+                    <xs:documentation>Haut mit Lymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="7.-">
+                <xs:annotation>
+                    <xs:documentation>Haut ohne Lymphknoten</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="7.1.">
+                <xs:annotation>
+                    <xs:documentation>Primärer Hauttumor</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="7.2.">
+                <xs:annotation>
+                    <xs:documentation>Hautmetastasen</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="8.">
+                <xs:annotation>
+                    <xs:documentation>Sonstiges</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="8.1.">
+                <xs:annotation>
+                    <xs:documentation>Ganzkörperbestrahlung</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="8.2.">
+                <xs:annotation>
+                    <xs:documentation>Mantelfeldbestrahlung</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="Diagnose_Typ">
+        <xs:sequence>
+            <xs:element name="Primaertumor_Diagnosetext" type="Diagnosetext_Typ" minOccurs="0"/>
+            <xs:element name="Primaertumor_Topographie_ICD_O" type="Topographie_ICD_O_Typ" minOccurs="0"/>
+            <xs:element name="Primaertumor_Topographie_Freitext" type="Freitext255_Typ" minOccurs="0"/>
+            <xs:element name="Diagnosesicherung">
+                <xs:annotation>
+                    <xs:documentation>Höchste erreichte Diagnosesicherheit zum Diagnosedatum (siehe BfArM, ICD-O-3.2: Ergänzende Informationen, Abschnitt 4.5. "Sicherheit der Diagnose").</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="1">
+                            <xs:annotation>
+                                <xs:documentation>Klinisch ohne tumorspezifische Diagnostik (nur körperliche Untersuchung)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="2">
+                            <xs:annotation>
+                                <xs:documentation>Klinisch: Klinische Diagnose vor dem Sterbedatum durchgeführt; schließt diagnostische Techniken, inklusive Röntgen, Endoskopie, weitere bildgebende Verfahren, Ultraschall, exploratorische Chirurgie (Laparatomie, etc.) und Autopsie, ohne mikroskopische Gewebediagnose, ein.</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="4">
+                            <xs:annotation>
+                                <xs:documentation>Spezifische Tumormarker</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="5">
+                            <xs:annotation>
+                                <xs:documentation>Zytologisch: Untersuchung von Zellen aus primären Lokalisationen inklusive Flüssigkeitsaspirationen mittels Endoskopien oder Nadeln. Schließt mikroskopische Untersuchungen von peripheren Blutausstrichen und Ausstrichen von Beckenkammaspirationen ein.</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="6">
+                            <xs:annotation>
+                                <xs:documentation>Histologie einer Metastase.</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="7">
+                            <xs:annotation>
+                                <xs:documentation>Veraltet; Besser Verwendung von 7.1, 7.2 oder 7.3</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="7.1">
+                            <xs:annotation>
+                                <xs:documentation>Histologie des Primärtumors: Histologische Untersuchung von Gewebe des Primärtumors einschließlich aller Schnitttechniken und Knochenmarksbiopsien.</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="7.2">
+                            <xs:annotation>
+                                <xs:documentation>Histologie Metastase: Histologische Untersuchung des Gewebes aus einer Metastase</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="7.3">
+                            <xs:annotation>
+                                <xs:documentation>Histologie der Autopsie: Histologische Untersuchung des Gewebes bei einer Autopsie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="8">
+                            <xs:annotation>
+                                <xs:documentation>Zytogenetisch und/oder molekularer Test</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="9">
+                            <xs:annotation>
+                                <xs:documentation>Unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Menge_Fruehere_Tumorerkrankung" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Fruehere_Tumorerkrankung" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="Freitext" type="Freitext255_Typ" minOccurs="0">
+                                        <xs:annotation>
+                                            <xs:documentation>Freitext zu Tumorerkrankungen die in der Anamnese zu einem früheren Zeitpunkt diagnostiziert/behandelt wurden.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="ICD" type="Tumor_ICD_Typ" minOccurs="0">
+                                        <xs:annotation>
+                                            <xs:documentation>ICD-Code, falls vorhanden</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="Diagnosedatum" type="Datum_nur_Jahr_Typ" minOccurs="0">
+                                        <xs:annotation>
+                                            <xs:documentation>Jahr der früheren Tumorerkrankung</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Histologie" type="Histologie_Typ" minOccurs="0"/>
+            <xs:element name="Menge_FM" type="Menge_FM_Typ" minOccurs="0"/>
+            <xs:element name="cTNM" type="TNM_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Prätherapeutisches TNM</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="pTNM" type="TNM_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Postoperatives TNM. Es ist nicht nötig, dass alle Bestandteile der TNM-Formel die Einstufung 'p' aufweisen.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Menge_Weitere_Klassifikation" type="Menge_Weitere_Klassifikation_Typ" minOccurs="0"/>
+            <xs:element name="Menge_Genetik" type="Menge_Genetik_Typ" minOccurs="0"/>
+            <xs:element name="Allgemeiner_Leistungszustand" type="Allgemeiner_Leistungszustand_Typ"/>
+            <xs:element name="Modul_Allgemein" type="Modul_Allgemein_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Mamma" type="Modul_Mamma_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Darm" type="Modul_Darm_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Prostata" type="Modul_Prostata_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Malignes_Melanom" type="Modul_Malignes_Melanom_Typ" minOccurs="0"/>
+            <xs:element name="Modul_DKKR" type="Modul_DKKR_Typ" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Pathologie_Typ">
+        <xs:sequence>
+            <xs:element name="Primaertumor_Diagnosetext" type="Diagnosetext_Typ" minOccurs="0"/>
+            <xs:element name="Primaertumor_Topographie_ICD_O" type="Topographie_ICD_O_Typ" minOccurs="0"/>
+            <xs:element name="Primaertumor_Topographie_Freitext" type="Freitext255_Typ" minOccurs="0"/>
+            <xs:element name="Diagnosesicherung">
+                <xs:annotation>
+                    <xs:documentation>
+                        Höchste erreichte Diagnosesicherheit zum Diagnosedatum (siehe BfArM, ICD-O-3.2: Ergänzende Informationen, Abschnitt 4.5. "Sicherheit der Diagnose").
+                        ohne 1 = Klinisch ohne tumorspezifische Diagnostik (nur körperliche Untersuchung)
+                        ohne 2 = Klinisch: Klinische Diagnose vor dem Sterbedatum durchgeführt; schließt diagnostische Techniken, inklusive Röntgen, Endoskopie, weitere bildgebende Verfahren, Ultraschall, exploratorische Chirurgie (Laparatomie, etc.) und Autopsie, ohne mikroskopische Gewebediagnose, ein.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="4">
+                            <xs:annotation>
+                                <xs:documentation>Spezifische Tumormarker</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="5">
+                            <xs:annotation>
+                                <xs:documentation>Zytologisch: Untersuchung von Zellen aus primären Lokalisationen inklusive Flüssigkeitsaspirationen mittels Endoskopien oder Nadeln. Schließt mikroskopische Untersuchungen von peripheren Blutausstrichen und Ausstrichen von Beckenkammaspirationen ein.</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="6">
+                            <xs:annotation>
+                                <xs:documentation>Histologie einer Metastase.</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="7">
+                            <xs:annotation>
+                                <xs:documentation>Histologisch: Histologie des Primärtumors: Histologische Untersuchung von Gewebe des Primärtumors einschließlich aller Schnitttechniken und Knochenmarksbiopsien. Dies schließt Proben des Primärtumors aus Autopsien ein. Histologische Untersuchung des Gewebes aus einer Metastase, einschließlich bei Autopsie.</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="9">
+                            <xs:annotation>
+                                <xs:documentation>Unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Histologie" type="Histologie_Typ" minOccurs="0"/>
+            <xs:element name="Menge_FM" type="Menge_FM_Typ" minOccurs="0"/>
+            <xs:element name="cTNM" type="TNM_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Prätherapeutisches TNM</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="pTNM" type="TNM_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Postoperatives TNM. Es ist nicht nötig, dass alle Bestandteile der TNM-Formel die Einstufung 'p' aufweisen.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Lokale_Beurteilung_Residualstatus" type="R_Typ" minOccurs="0"/>
+            <xs:element name="Menge_Weitere_Klassifikation" type="Menge_Weitere_Klassifikation_Typ" minOccurs="0"/>
+            <xs:element name="Menge_Genetik" type="Menge_Genetik_Typ" minOccurs="0"/>
+            <xs:element name="Einsender">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:choice>
+                            <xs:element name="strukturiert">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:annotation>
+                                            <xs:documentation>Strukturierte, bevorzugte Form</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:element name="Titel" type="Namenstring255_Typ" minOccurs="0"/>
+                                        <xs:element name="Vornamen" type="Namenstring255_Typ" minOccurs="0"/>
+                                        <xs:element name="Nachname" type="Namenstring255_Typ" minOccurs="0"/>
+                                        <xs:element name="Einrichtung" type="Adressstring255_Typ" minOccurs="0"/>
+                                        <xs:element name="Abteilung" type="Adressstring255_Typ" minOccurs="0"/>
+                                        <xs:element name="Strasse" type="Adressstring255_Typ" minOccurs="0"/>
+                                        <xs:element name="Hausnummer" type="Adressstring255_Typ" minOccurs="0"/>
+                                        <xs:element name="Land" type="ISO3166Alpha2Code_Typ" minOccurs="0"/>
+                                        <xs:element name="PLZ" type="Adressstring10_Typ" minOccurs="0"/>
+                                        <xs:element name="Ort" type="Adressstring255_Typ" minOccurs="0"/>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="unstrukturiert">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:annotation>
+                                            <xs:documentation>Nicht strukturierte, alternative Form</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:element name="Adresse1" type="Adressstring255_Typ"/>
+                                        <xs:element name="Adresse2" type="Adressstring255_Typ" minOccurs="0"/>
+                                        <xs:element name="Adresse3" type="Adressstring255_Typ" minOccurs="0"/>
+                                        <xs:element name="Adresse4" type="Adressstring255_Typ" minOccurs="0"/>
+                                        <xs:element name="Adresse5" type="Adressstring255_Typ" minOccurs="0"/>
+                                        <xs:element name="Adresse6" type="Adressstring255_Typ" minOccurs="0"/>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:choice>
+                        <xs:element name="Ident_Nummern" type="Ident_Nummern_Typ" minOccurs="0"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Befundtext" type="FreitextCLOB_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Vollständiger Befundbericht des Pathologen (Originalbenennung "Befund")</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Modul_Mamma" type="Modul_Mamma_patho_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Darm" type="Modul_Darm_patho_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Prostata" type="Modul_Prostata_patho_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Malignes_Melanom" type="Modul_Malignes_Melanom_patho_Typ" minOccurs="0"/>
+            <xs:element name="Modul_DKKR" type="Modul_DKKR_Typ" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="Befund_ID" type="FreitextID_Typ" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="OP_Typ">
+        <xs:sequence>
+            <xs:element name="Intention">
+                <xs:annotation>
+                    <xs:documentation>
+                        Gibt an, mit welchem Ziel die Operation geplant wurde.
+                        Die Angabe S = Sonstiges wird z.B. bei Tracheostomie vor Radiochenotherapie bei Kopf/Hals verwendet
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="K">
+                            <xs:annotation>
+                                <xs:documentation>kurativ</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="P">
+                            <xs:annotation>
+                                <xs:documentation>palliativ</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="D">
+                            <xs:annotation>
+                                <xs:documentation>diagnostisch</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="R">
+                            <xs:annotation>
+                                <xs:documentation>Revision/Komplikation</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="S">
+                            <xs:annotation>
+                                <xs:documentation>Sonstiges</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="X">
+                            <xs:annotation>
+                                <xs:documentation>fehlende Angabe</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Datum" type="Datum_Tag_genau_Typ"/>
+            <xs:element name="Menge_OPS" minOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="OPS" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="Code">
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:minLength value="5"/>
+                                                <xs:maxLength value="9"/>
+                                                <xs:pattern value="[135689]-\d\d[0-9a-hj-km-z](\.([0-9a-hj-kmnp-z]){1,2}){0,1}([RLB]){0,1}"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:element>
+                                    <xs:element name="Version">
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:pattern value="200[4-9]|20[12]\d"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Histologie" type="Histologie_Typ" minOccurs="0"/>
+            <xs:element name="TNM" type="TNM_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Residualstatus" type="Residualstatus_Typ" minOccurs="0"/>
+            <xs:element name="Menge_Weitere_Klassifikation" type="Menge_Weitere_Klassifikation_Typ" minOccurs="0"/>
+            <xs:element name="Menge_Genetik" type="Menge_Genetik_Typ" minOccurs="0"/>
+            <xs:element name="Komplikationen">
+                <xs:complexType>
+                    <xs:choice>
+                        <xs:element name="Komplikation_nein_oder_unbekannt">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="N">
+                                        <xs:annotation>
+                                            <xs:documentation>Nein (keine Komplikation aufgetreten)</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="U">
+                                        <xs:annotation>
+                                            <xs:documentation>unbekannt (unbekannt, ob Komplikation aufgetreten oder nicht)</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="Menge_Komplikation">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="Komplikation" type="Komplikation_Typ" maxOccurs="unbounded"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Menge_Operateur" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Operateur" type="Operateur_Typ" minOccurs="1" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Modul_Allgemein" type="Modul_Allgemein_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Mamma" type="Modul_Mamma_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Darm" type="Modul_Darm_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Prostata" type="Modul_Prostata_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Malignes_Melanom" type="Modul_Malignes_Melanom_Typ" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="OP_ID" type="FreitextID_Typ" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="Komplikation_Typ">
+        <xs:choice>
+            <xs:element name="Kuerzel">
+                <xs:annotation>
+                    <xs:documentation>
+                        Gibt an, ob eine oder keine Komplikation aufgetreten ist, bzw. wenn eine aufgetreten ist, welche.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="ABD">
+                            <xs:annotation>
+                                <xs:documentation>Abszeß in einem Drainagekanal</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="ABS">
+                            <xs:annotation>
+                                <xs:documentation>Abszeß, intraabdominaler oder intrathorakaler</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="ASF">
+                            <xs:annotation>
+                                <xs:documentation>Abszeß, subfaszialer</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="ANI">
+                            <xs:annotation>
+                                <xs:documentation>Akute Niereninsuffizienz</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="AEP">
+                            <xs:annotation>
+                                <xs:documentation>Alkoholentzugspsychose</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="ALR">
+                            <xs:annotation>
+                                <xs:documentation>Allergische Reaktion ohne Schocksymptomatik</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="ANS">
+                            <xs:annotation>
+                                <xs:documentation>Anaphylaktischer Schock</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="AEE">
+                            <xs:annotation>
+                                <xs:documentation>Anastomoseninsuffizienz einer Enterostomie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="API">
+                            <xs:annotation>
+                                <xs:documentation>Apoplektischer Insult</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="BIF">
+                            <xs:annotation>
+                                <xs:documentation>Biliäre Fistel</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="BOG">
+                            <xs:annotation>
+                                <xs:documentation>Blutung, obere gastrointestinale (z.B "Stressulkus")</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="BOE">
+                            <xs:annotation>
+                                <xs:documentation>Bolusverlegung eines Endotubus</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="BSI">
+                            <xs:annotation>
+                                <xs:documentation>Bronchusstumpfinsuffizienz</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="CHI">
+                            <xs:annotation>
+                                <xs:documentation>Cholangitis</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="DAI">
+                            <xs:annotation>
+                                <xs:documentation>Darmanastomoseinsuffizienz</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="DPS">
+                            <xs:annotation>
+                                <xs:documentation>Darmpassagestörungen (z.B. protrahierte Atonie, Subileus, Ileus) </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="DIC">
+                            <xs:annotation>
+                                <xs:documentation>Disseminierte intravasale Koagulopathie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="DEP">
+                            <xs:annotation>
+                                <xs:documentation>Drogenentzugspsychose</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="DLU">
+                            <xs:annotation>
+                                <xs:documentation>Druck- und Lagerungsschäden, z.B. Dekubitalulzera</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="DSI">
+                            <xs:annotation>
+                                <xs:documentation>Duodenalstumpfinsuffizienz</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="ENF">
+                            <xs:annotation>
+                                <xs:documentation>Enterale Fistel</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="GER">
+                            <xs:annotation>
+                                <xs:documentation>Gerinnungsstörung</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="HEM">
+                            <xs:annotation>
+                                <xs:documentation>Hämatemesis</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="HUR">
+                            <xs:annotation>
+                                <xs:documentation>Hämaturie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="HAE">
+                            <xs:annotation>
+                                <xs:documentation>Hämorrhagischer Schock</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="HFI">
+                            <xs:annotation>
+                                <xs:documentation>Harnfistel</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="HNK">
+                            <xs:annotation>
+                                <xs:documentation>Hautnekrose im Operationsbereich</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="HZI">
+                            <xs:annotation>
+                                <xs:documentation>Herzinsuffizienz</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="HRS">
+                            <xs:annotation>
+                                <xs:documentation>Herzrhythmusstörungen</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="HNA">
+                            <xs:annotation>
+                                <xs:documentation>Hirnnervenausfälle</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="HOP">
+                            <xs:annotation>
+                                <xs:documentation>Hirnorganisches Psychosyndrom (z.B. "Durchgangssyndrom")</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="HYB">
+                            <xs:annotation>
+                                <xs:documentation>Hyperbilirubinämie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="HYF">
+                            <xs:annotation>
+                                <xs:documentation>Hypopharynxfistel</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IFV">
+                            <xs:annotation>
+                                <xs:documentation>Ileofemorale Venenthrombose</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="KAS">
+                            <xs:annotation>
+                                <xs:documentation>Kardiogener Schock</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="KES">
+                            <xs:annotation>
+                                <xs:documentation>Komplikationen einer Stomaanlage</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="KIM">
+                            <xs:annotation>
+                                <xs:documentation>Komplikation eines Implantates (Gefäßprothese, Totalendoprothese, Katheter), z.B. Dislokation</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="KRA">
+                            <xs:annotation>
+                                <xs:documentation>Krampfanfall</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="KDS">
+                            <xs:annotation>
+                                <xs:documentation>Kurzdarmsyndrom</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="LEV">
+                            <xs:annotation>
+                                <xs:documentation>Leberversagen</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="LOE">
+                            <xs:annotation>
+                                <xs:documentation>Lungenödem</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="LYF">
+                            <xs:annotation>
+                                <xs:documentation>Lymphfistel</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="LYE">
+                            <xs:annotation>
+                                <xs:documentation>Lymphozele</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="MES">
+                            <xs:annotation>
+                                <xs:documentation>Magenentleerungsstörung</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="MIL">
+                            <xs:annotation>
+                                <xs:documentation>Mechanischer Ileus</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="MED">
+                            <xs:annotation>
+                                <xs:documentation>Mediastinitis</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="MAT">
+                            <xs:annotation>
+                                <xs:documentation>Mesenterialarterien- oder -venenthrombose</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="MYI">
+                            <xs:annotation>
+                                <xs:documentation>Myokardinfarkt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="RNB">
+                            <xs:annotation>
+                                <xs:documentation>Nachblutung, revisionsbedürftig, anderweitig nicht erwähnt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="NAB">
+                            <xs:annotation>
+                                <xs:documentation>Nachblutung, nicht revisionsbedürftig, anderweitig nicht erwähnt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="NIN">
+                            <xs:annotation>
+                                <xs:documentation>Nahtinsuffizienz, anderweitig nicht erwähnt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="OES">
+                            <xs:annotation>
+                                <xs:documentation>Ösophagitis</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="OSM">
+                            <xs:annotation>
+                                <xs:documentation>Osteitis, Osteomyelitis</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="PAF">
+                            <xs:annotation>
+                                <xs:documentation>Pankreasfistel</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="PIT">
+                            <xs:annotation>
+                                <xs:documentation>Pankreatitis</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="PAB">
+                            <xs:annotation>
+                                <xs:documentation>Peranale Blutung</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="PPA">
+                            <xs:annotation>
+                                <xs:documentation>Periphere Parese</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="PAV">
+                            <xs:annotation>
+                                <xs:documentation>Peripherer arterieller Verschluß (Embolie, Thrombose)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="PER">
+                            <xs:annotation>
+                                <xs:documentation>Peritonitis</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="PLB">
+                            <xs:annotation>
+                                <xs:documentation>Platzbauch</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="PEY">
+                            <xs:annotation>
+                                <xs:documentation>Pleuraempyem</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="PLE">
+                            <xs:annotation>
+                                <xs:documentation>Pleuraerguß</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="PMN">
+                            <xs:annotation>
+                                <xs:documentation>Pneumonie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="PNT">
+                            <xs:annotation>
+                                <xs:documentation>Pneumothorax</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="PDA">
+                            <xs:annotation>
+                                <xs:documentation>Protrahierte Darmatonie (paralytischer Ileus)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="PAE">
+                            <xs:annotation>
+                                <xs:documentation>Pulmonalarterienembolie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="RPA">
+                            <xs:annotation>
+                                <xs:documentation>Rekurrensparese</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="RIN">
+                            <xs:annotation>
+                                <xs:documentation>Respiratorische Insuffizienz</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="SKI">
+                            <xs:annotation>
+                                <xs:documentation>Septische Komplikation eines Implantates</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="SES">
+                            <xs:annotation>
+                                <xs:documentation>Septischer Schock</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="SFH">
+                            <xs:annotation>
+                                <xs:documentation>Störungen des Flüssigkeits-, Elektrolyt- und Säurebasenhaushaltes</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="STK">
+                            <xs:annotation>
+                                <xs:documentation>Stomakomplikation (z.B. Blutung, Nekrose, Stenose)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="TZP">
+                            <xs:annotation>
+                                <xs:documentation>Thrombozytopenie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="TIA">
+                            <xs:annotation>
+                                <xs:documentation>TIA (transitorische ischämische Attacke) oder RIND (reversibles ischämisches neurologisches Defizit)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="TRZ">
+                            <xs:annotation>
+                                <xs:documentation>Transfusionszwischenfall</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="WUH">
+                            <xs:annotation>
+                                <xs:documentation>Wundhämatom (konservativ therapiert)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="WSS">
+                            <xs:annotation>
+                                <xs:documentation>Wundheilungsstörung, subkutane</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="ICD" type="Komplikation_ICD_Typ"/>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="Komplikation_ICD_Typ">
+        <xs:sequence>
+            <xs:element name="Code">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:pattern value="[E|G|I|K|M|R|T]\d\d(\.\d(\d)?)?"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Version" type="ICD_Version_Typ"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Operateur_Typ">
+        <xs:sequence>
+            <xs:element name="Nachname" type="Namenstring255_Typ"/>
+            <xs:element name="Vornamen" type="Namenstring255_Typ" minOccurs="0"/>
+            <xs:element name="Hauptoperateur" type="JNU_Typ"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="ST_Typ">
+        <xs:sequence>
+            <xs:element name="Meldeanlass">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="behandlungsbeginn"/>
+                        <xs:enumeration value="behandlungsende"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Intention">
+                <xs:annotation>
+                    <xs:documentation>
+
+                        Gibt an, mit welcher Intention die Strahlentherapie geplant wurde.
+                        Prophylaktisch/Salvage kann als kurativ oder palliativ kodiert werden.
+                        "lokal kurativ" gibt an, wenn das Therapiekonzept lediglich lokal kurativ ist, steht also zwischen Kurativ und Palliativ
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="K">
+                            <xs:annotation>
+                                <xs:documentation>Kurativ</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="P">
+                            <xs:annotation>
+                                <xs:documentation>Palliativ</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="O">
+                            <xs:annotation>
+                                <xs:documentation>lokal kurativ bei Oligometastasierung</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="S">
+                            <xs:annotation>
+                                <xs:documentation>Sonstiges</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="X">
+                            <xs:annotation>
+                                <xs:documentation>Keine Angabe</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Stellung_OP">
+                <xs:annotation>
+                    <xs:documentation>
+                        Gibt an, in welchem Bezug zu einer operativen Therapie die Bestrahlung steht.
+                        Hinweise:
+                        A = adjuvant gilt für Therapien nach R0 Resektion
+                        Z = additiv gilt für Therapien nach R1/R2 und RX Resektion
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="O">
+                            <xs:annotation>
+                                <xs:documentation>Ohne Bezug zu einer operativen Therapie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="A">
+                            <xs:annotation>
+                                <xs:documentation>adjuvant</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="N">
+                            <xs:annotation>
+                                <xs:documentation>neoadjuvant</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="I">
+                            <xs:annotation>
+                                <xs:documentation>intraoperativ</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="Z">
+                            <xs:annotation>
+                                <xs:documentation>additiv</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="S">
+                            <xs:annotation>
+                                <xs:documentation>Sonstiges</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Menge_Bestrahlung" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Bestrahlung" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="Beginn" type="Datum_Tag_genau_Typ" minOccurs="0"/>
+                                    <xs:element name="Ende" type="Datum_Tag_genau_Typ" minOccurs="0"/>
+                                    <xs:element name="Applikationsart">
+                                        <xs:complexType>
+                                            <xs:choice>
+                                                <xs:element name="Perkutan">
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="Radiochemo" minOccurs="0">
+                                                                <xs:simpleType>
+                                                                    <xs:restriction base="xs:string">
+                                                                        <xs:enumeration value="RCJ">
+                                                                            <xs:annotation>
+                                                                                <xs:documentation>mit Chemotherapie/Sensitizer</xs:documentation>
+                                                                            </xs:annotation>
+                                                                        </xs:enumeration>
+                                                                        <xs:enumeration value="RCN">
+                                                                            <xs:annotation>
+                                                                                <xs:documentation>ohne Chemotherapie/Sensitizer</xs:documentation>
+                                                                            </xs:annotation>
+                                                                        </xs:enumeration>
+                                                                    </xs:restriction>
+                                                                </xs:simpleType>
+                                                            </xs:element>
+                                                            <xs:element name="Stereotaktisch" minOccurs="0">
+                                                                <xs:simpleType>
+                                                                    <xs:restriction base="xs:string">
+                                                                        <xs:enumeration value="ST">
+                                                                            <xs:annotation>
+                                                                                <xs:documentation>stereotaktisch</xs:documentation>
+                                                                            </xs:annotation>
+                                                                        </xs:enumeration>
+                                                                    </xs:restriction>
+                                                                </xs:simpleType>
+                                                            </xs:element>
+                                                            <xs:element name="Atemgetriggert" minOccurs="0">
+                                                                <xs:simpleType>
+                                                                    <xs:restriction base="xs:string">
+                                                                        <xs:enumeration value="4D">
+                                                                            <xs:annotation>
+                                                                                <xs:documentation>atemgetriggert</xs:documentation>
+                                                                            </xs:annotation>
+                                                                        </xs:enumeration>
+                                                                    </xs:restriction>
+                                                                </xs:simpleType>
+                                                            </xs:element>
+                                                            <xs:element name="Zielgebiet" type="Zielgebiet_Typ"/>
+                                                            <xs:element name="Seite_Zielgebiet" type="Seite_Zielgebiet_Typ"/>
+                                                            <xs:element name="Strahlenart" type="Strahlenart_Typ" minOccurs="0"/>
+                                                            <xs:element name="Gesamtdosis" type="Strahlendosis_Typ" minOccurs="0"/>
+                                                            <xs:element name="Einzeldosis" type="Strahlendosis_Typ" minOccurs="0"/>
+                                                            <xs:element name="Boost" type="Boost_Typ" minOccurs="0"/>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="Kontakt">
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="Interstitiell_endokavitaer">
+                                                                <xs:simpleType>
+                                                                    <xs:restriction base="xs:string">
+                                                                        <xs:enumeration value="I">
+                                                                            <xs:annotation>
+                                                                                <xs:documentation>interstitiell</xs:documentation>
+                                                                            </xs:annotation>
+                                                                        </xs:enumeration>
+                                                                        <xs:enumeration value="K">
+                                                                            <xs:annotation>
+                                                                                <xs:documentation>endokavitär</xs:documentation>
+                                                                            </xs:annotation>
+                                                                        </xs:enumeration>
+                                                                    </xs:restriction>
+                                                                </xs:simpleType>
+                                                            </xs:element>
+                                                            <xs:element name="Rate_Type">
+                                                                <xs:simpleType>
+                                                                    <xs:restriction base="xs:string">
+                                                                        <xs:enumeration value="HDR">
+                                                                            <xs:annotation>
+                                                                                <xs:documentation>high dose rate therapy</xs:documentation>
+                                                                            </xs:annotation>
+                                                                        </xs:enumeration>
+                                                                        <xs:enumeration value="LDR">
+                                                                            <xs:annotation>
+                                                                                <xs:documentation>low dose rate therapy</xs:documentation>
+                                                                            </xs:annotation>
+                                                                        </xs:enumeration>
+                                                                        <xs:enumeration value="PDR">
+                                                                            <xs:annotation>
+                                                                                <xs:documentation>pulsed dose rate therapy</xs:documentation>
+                                                                            </xs:annotation>
+                                                                        </xs:enumeration>
+                                                                    </xs:restriction>
+                                                                </xs:simpleType>
+                                                            </xs:element>
+                                                            <xs:element name="Zielgebiet" type="Zielgebiet_Typ"/>
+                                                            <xs:element name="Seite_Zielgebiet" type="Seite_Zielgebiet_Typ"/>
+                                                            <xs:element name="Strahlenart" type="Strahlenart_Kontakt_Typ" minOccurs="0"/>
+                                                            <xs:element name="Gesamtdosis" type="Strahlendosis_Typ" minOccurs="0"/>
+                                                            <xs:element name="Einzeldosis" type="Strahlendosis_Typ" minOccurs="0"/>
+                                                            <xs:element name="Boost" type="Boost_Typ" minOccurs="0"/>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="Metabolisch">
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="Metabolisch_Typ">
+                                                                <xs:simpleType>
+                                                                    <xs:restriction base="xs:string">
+                                                                        <xs:enumeration value="SIRT">
+                                                                            <xs:annotation>
+                                                                                <xs:documentation>selektive interne Radio-Therapie</xs:documentation>
+                                                                            </xs:annotation>
+                                                                        </xs:enumeration>
+                                                                        <xs:enumeration value="PRRT">
+                                                                            <xs:annotation>
+                                                                                <xs:documentation>Peptid-Radio-Rezeptor-Therapie</xs:documentation>
+                                                                            </xs:annotation>
+                                                                        </xs:enumeration>
+                                                                        <xs:enumeration value="PSMA">
+                                                                            <xs:annotation>
+                                                                                <xs:documentation>PSMA-Therapie</xs:documentation>
+                                                                            </xs:annotation>
+                                                                        </xs:enumeration>
+                                                                        <xs:enumeration value="RJT">
+                                                                            <xs:annotation>
+                                                                                <xs:documentation>Radiojod-Therapie</xs:documentation>
+                                                                            </xs:annotation>
+                                                                        </xs:enumeration>
+                                                                        <xs:enumeration value="RIT">
+                                                                            <xs:annotation>
+                                                                                <xs:documentation>Radioimmun-Therapie</xs:documentation>
+                                                                            </xs:annotation>
+                                                                        </xs:enumeration>
+                                                                    </xs:restriction>
+                                                                </xs:simpleType>
+                                                            </xs:element>
+                                                            <xs:element name="Zielgebiet" type="Zielgebiet_Typ" minOccurs="0"/>
+                                                            <xs:element name="Seite_Zielgebiet" type="Seite_Zielgebiet_Typ" minOccurs="0"/>
+                                                            <xs:element name="Strahlenart" type="Nuklide_Typ" minOccurs="0"/>
+                                                            <xs:element name="Gesamtdosis" type="Aktivitaets_Typ" minOccurs="0"/>
+                                                            <xs:element name="Einzeldosis" type="Aktivitaets_Typ" minOccurs="0"/>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="Sonstige">
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="Zielgebiet" type="Zielgebiet_Typ" minOccurs="0"/>
+                                                            <xs:element name="Seite_Zielgebiet" type="Seite_Zielgebiet_Typ" minOccurs="0"/>
+                                                            <xs:element name="Gesamtdosis" type="Strahlendosis_Typ" minOccurs="0"/>
+                                                            <xs:element name="Einzeldosis" type="Strahlendosis_Typ" minOccurs="0"/>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:choice>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Ende_Grund" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Gibt den Grund an, warum die Strahlentherapie beendet wurde.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="E">
+                            <xs:annotation>
+                                <xs:documentation>Reguläres Ende</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="F">
+                            <xs:annotation>
+                                <xs:documentation>Zieldosis erreicht mit Unterbrechung &gt; 3 Kalendertage</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="A">
+                            <xs:annotation>
+                                <xs:documentation>Abbruch wegen Nebenwirkungen</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="P">
+                            <xs:annotation>
+                                <xs:documentation>Abbruch wegen Progress</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="S">
+                            <xs:annotation>
+                                <xs:documentation>Abbruch aus sonstigen Gründen</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="V">
+                            <xs:annotation>
+                                <xs:documentation>Patient verweigert weitere Therapie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="T">
+                            <xs:annotation>
+                                <xs:documentation>Patient verstorben</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Nebenwirkungen" type="Nebenwirkung_Typ"/>
+            <xs:element name="Modul_Allgemein" type="Modul_Allgemein_Typ" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="ST_ID" type="FreitextID_Typ" use="optional"/>
+    </xs:complexType>
+    <xs:simpleType name="Strahlenart_Typ">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="UH">
+                <xs:annotation>
+                    <xs:documentation>Photonen (ultraharte Röntgenstrahlen, inkl. Gamma-Strahler)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="EL">
+                <xs:annotation>
+                    <xs:documentation>Elektronen</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NE">
+                <xs:annotation>
+                    <xs:documentation>Neutronen</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PN">
+                <xs:annotation>
+                    <xs:documentation>Protonen (leichte Wasserstoffionen/H1/Leichtionen)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SI">
+                <xs:annotation>
+                    <xs:documentation>Schwerionen (schwere Kohlenstoff-Ionen/C12/Sauerstoffionen/Heliumionen)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="RO">
+                <xs:annotation>
+                    <xs:documentation>Weichstrahl (kV)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Co-60">
+                <xs:annotation>
+                    <xs:documentation>Co-60</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SO">
+                <xs:annotation>
+                    <xs:documentation>sonstige</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Strahlenart_Kontakt_Typ">
+        <xs:annotation>
+            <xs:documentation>
+                UH ist der am meisten verbreitete Typ
+                Elektronenstrahlen kommen nur bei kurzer Reichweite - Aderhautmelanom und Haut - zum Einsatz
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="Strahlenart_Typ">
+            <xs:enumeration value="UH"/>
+            <xs:enumeration value="EL"/>
+            <xs:enumeration value="SO"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Nuklide_Typ">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Lu-177">
+                <xs:annotation>
+                    <xs:documentation>Lu-177</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="J-131">
+                <xs:annotation>
+                    <xs:documentation>J-131</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Y-90">
+                <xs:annotation>
+                    <xs:documentation>Y-90</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Ra-223">
+                <xs:annotation>
+                    <xs:documentation>Ra-223</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Ac-225">
+                <xs:annotation>
+                    <xs:documentation>Ac-225</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Sm-153">
+                <xs:annotation>
+                    <xs:documentation>Sm-153</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Tb-161">
+                <xs:annotation>
+                    <xs:documentation>Tb-161</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Sr-89">
+                <xs:annotation>
+                    <xs:documentation>Sr-89</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Ir-192">
+                <xs:annotation>
+                    <xs:documentation>Ir-192</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SONU">
+                <xs:annotation>
+                    <xs:documentation>Sonstige Nuklide</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="Boost_Typ">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="J">
+                <xs:annotation>
+                    <xs:documentation>ja, mit Boost o. n. A.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SIB">
+                <xs:annotation>
+                    <xs:documentation>simultan integrierter Boost</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SEQ">
+                <xs:annotation>
+                    <xs:documentation>sequentieller Boost</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="KON">
+                <xs:annotation>
+                    <xs:documentation>konkomitanter Boost</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="N">
+                <xs:annotation>
+                    <xs:documentation>nein, ohne Boost</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="Strahlendosis_Typ">
+        <xs:sequence>
+            <xs:element name="Dosis">
+                <xs:simpleType>
+                    <xs:restriction base="xs:decimal">
+                        <xs:minExclusive value="0.0"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Einheit">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="Gy">
+                            <xs:annotation>
+                                <xs:documentation>Dosis in Gray</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Aktivitaets_Typ">
+        <xs:sequence>
+            <xs:element name="Dosis">
+                <xs:simpleType>
+                    <xs:restriction base="xs:decimal">
+                        <xs:minExclusive value="0.0"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Einheit">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="GBq">
+                            <xs:annotation>
+                                <xs:documentation>Dosis in Gigabecquerel</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="MBq">
+                            <xs:annotation>
+                                <xs:documentation>Dosis in Megabecquerel</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="kBq">
+                            <xs:annotation>
+                                <xs:documentation>Dosis in Kilobecquerel</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="Zielgebiet_Typ">
+        <xs:choice>
+            <xs:element name="CodeVersion2021" type="oBDS_Zielgebiet2021_Typ"/>
+            <xs:element name="CodeVersion2014" type="oBDS_Zielgebiet2014_Typ"/>
+        </xs:choice>
+    </xs:complexType>
+    <xs:simpleType name="Seite_Zielgebiet_Typ">
+        <xs:annotation>
+            <xs:documentation>
+                Gibt die Seitenlokalisation des Zielgebietes an
+                Hinweise:
+                Bei Zielgebieten, die durch "(r, l)" gekennzeichnet sind, ist eine Seitenangabe Pflicht.
+                Bei beidseitiger Bestrahlung paariger Organe sind die Bestrahlungen einzeln zu melden.
+                Paariges Zielgebiet ist ein anatomischer Begriff und nicht zu verwechseln mit paarigen Organen.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="L">
+                <xs:annotation>
+                    <xs:documentation>links</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="R">
+                <xs:annotation>
+                    <xs:documentation>rechts</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="B">
+                <xs:annotation>
+                    <xs:documentation>beidseits</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="M">
+                <xs:annotation>
+                    <xs:documentation>mittig</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="U">
+                <xs:annotation>
+                    <xs:documentation>unbekannt</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="T">
+                <xs:annotation>
+                    <xs:documentation>trifft nicht zu</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="SYST_Typ">
+        <xs:sequence>
+            <xs:element name="Meldeanlass">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="behandlungsbeginn"/>
+                        <xs:enumeration value="behandlungsende"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Intention">
+                <xs:annotation>
+                    <xs:documentation>Gibt an, mit welcher Intention die systemische Therapie geplant wurde.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="K">
+                            <xs:annotation>
+                                <xs:documentation>kurativ</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="P">
+                            <xs:annotation>
+                                <xs:documentation>palliativ</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="S">
+                            <xs:annotation>
+                                <xs:documentation>Sonstiges</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="X">
+                            <xs:annotation>
+                                <xs:documentation>keine Angabe</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Stellung_OP">
+                <xs:annotation>
+                    <xs:documentation>Gibt an, in welchem Bezug zu einer operativen Therapie die systemische Therapie steht</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="O">
+                            <xs:annotation>
+                                <xs:documentation>ohne Bezug zu einer operativen Therapie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="A">
+                            <xs:annotation>
+                                <xs:documentation>adjuvant</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="N">
+                            <xs:annotation>
+                                <xs:documentation>neoadjuvant</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="I">
+                            <xs:annotation>
+                                <xs:documentation>intraoperativ</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="S">
+                            <xs:annotation>
+                                <xs:documentation>Sonstiges</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Therapieart">
+                <xs:annotation>
+                    <xs:documentation>Gibt an, welche Art der Therapie bzw. abwartende Strategie durchgeführt wurde.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="CH">
+                            <xs:annotation>
+                                <xs:documentation>Chemotherapie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="HO">
+                            <xs:annotation>
+                                <xs:documentation>Hormontherapie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IM">
+                            <xs:annotation>
+                                <xs:documentation>Immun-/Antikörpertherapie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="ZS">
+                            <xs:annotation>
+                                <xs:documentation>zielgerichtete Substanzen</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="CI">
+                            <xs:annotation>
+                                <xs:documentation>Chemo- + Immun-/Antikörpertherapie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="CZ">
+                            <xs:annotation>
+                                <xs:documentation>Chemotherapie + zielgerichtete Substanzen</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="CIZ">
+                            <xs:annotation>
+                                <xs:documentation>Chemo- + Immun-/Antikörpertherapie + zielgerichtete Substanzen</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="IZ">
+                            <xs:annotation>
+                                <xs:documentation>Immun-/Antikörpertherapie + zielgerichtete Substanzen</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="SZ">
+                            <xs:annotation>
+                                <xs:documentation>Stammzelltransplantation (inkl. Knochenmarktransplantation)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="AS">
+                            <xs:annotation>
+                                <xs:documentation>Active Surveillance</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="WS">
+                            <xs:annotation>
+                                <xs:documentation>Wait and see</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="WW">
+                            <xs:annotation>
+                                <xs:documentation>Watchful Waiting</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="SO">
+                            <xs:annotation>
+                                <xs:documentation>Sonstiges</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Protokoll" type="Freitext255E_Typ" minOccurs="0"/>
+            <xs:element name="Beginn" type="Datum_Tag_oder_Monat_genau_Typ"/>
+            <xs:element name="Menge_Substanz" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Gibt an, mit welcher Substanz die Systemtherapie durchgeführt wurde.
+                        Mehrere Substanzen sind einzeln anzugeben. Eine kommaseparierte Liste ist nicht zulässig.
+                        Substanzen können mit ihrer Bezeichnung oder als ATC-Code inklusive Version angegebenw erden.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Substanz" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:choice>
+                                    <xs:element name="Bezeichnung" type="Freitext255E_Typ"/>
+                                    <xs:element name="ATC">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="Code">
+                                                    <xs:simpleType>
+                                                        <xs:restriction base="xs:string">
+                                                            <xs:pattern value="[A-Z]\d\d[A-Z][A-Z]\d\d"/>
+                                                        </xs:restriction>
+                                                    </xs:simpleType>
+                                                </xs:element>
+                                                <xs:element name="Version">
+                                                    <xs:simpleType>
+                                                        <xs:restriction base="xs:string">
+                                                            <xs:pattern value="200[4-9]|20[12]\d"/>
+                                                        </xs:restriction>
+                                                    </xs:simpleType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:choice>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Ende_Grund" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Gibt den Grund an, warum die Systemtherapie beendet wurde.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="E">
+                            <xs:annotation>
+                                <xs:documentation>reguläres Ende</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="R">
+                            <xs:annotation>
+                                <xs:documentation>reguläres Ende mit Dosisreduktion</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="W">
+                            <xs:annotation>
+                                <xs:documentation>reguläres Ende mit Substanzwechsel</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="A">
+                            <xs:annotation>
+                                <xs:documentation>Abbruch wegen Nebenwirkungen</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="P">
+                            <xs:annotation>
+                                <xs:documentation>Abbruch wegen Progress</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="S">
+                            <xs:annotation>
+                                <xs:documentation>Abbruch aus sonstigen Gründen</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="V">
+                            <xs:annotation>
+                                <xs:documentation>Patient verweigert weitere Therapie</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="T">
+                            <xs:annotation>
+                                <xs:documentation>Patient verstorben</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Ende" type="Datum_Tag_genau_Typ" minOccurs="0"/>
+            <xs:element name="Nebenwirkungen" type="Nebenwirkung_Typ"/>
+            <xs:element name="Modul_Allgemein" type="Modul_Allgemein_Typ" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="SYST_ID" type="FreitextID_Typ" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="Verlauf_Typ">
+        <xs:sequence>
+            <xs:element name="Meldeanlass">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="statusaenderung"/>
+                        <xs:enumeration value="statusmeldung"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Untersuchungsdatum_Verlauf" type="Datum_Tag_genau_Typ"/>
+            <xs:element name="Gesamtbeurteilung_Tumorstatus">
+                <xs:annotation>
+                    <xs:documentation>
+                        Gesamtbeurteilung der Erkrankung unter Berücksichtigung aller Manifestationen.
+                        Hinweise:
+                        P = Progression (Fortschreiten der Erkrankung)
+                        Y = Rezidiv, jedes Wiederauftreten der Erkrankung bei vorheriger kompletter klinischer Tumorfreiheit (biochemisches Rezidiv, Lokalrezidiv und/oder Metastasierung)
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="V">
+                            <xs:annotation>
+                                <xs:documentation>Vollremission (complete remission, CR)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="T">
+                            <xs:annotation>
+                                <xs:documentation>Teilremission (partial remission, PR)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="K">
+                            <xs:annotation>
+                                <xs:documentation>keine Änderung (no change, NC) = stable disease</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="P">
+                            <xs:annotation>
+                                <xs:documentation>Progression</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="D">
+                            <xs:annotation>
+                                <xs:documentation>divergentes Geschehen</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="B">
+                            <xs:annotation>
+                                <xs:documentation>klinische Besserung des Zustandes, Kriterien für Teilremission jedoch nicht erfüllt (minimal response, MR)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="R">
+                            <xs:annotation>
+                                <xs:documentation>Vollremission mit residualen Auffälligkeiten (CRr)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="Y">
+                            <xs:annotation>
+                                <xs:documentation>Rezidiv</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>Beurteilung unmöglich</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="X">
+                            <xs:annotation>
+                                <xs:documentation>fehlende Angaben</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Verlauf_Lokaler_Tumorstatus" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Beurteilung der Situation im Primärtumorbereich
+                        Hinweis:
+                        T = Tumorreste (Residualtumor), unbekannt, ob Progress oder No Change (auch für noch nicht therapierte Primärtumoren zu verwenden)
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="K">
+                            <xs:annotation>
+                                <xs:documentation>kein Tumor nachweisbar</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="T">
+                            <xs:annotation>
+                                <xs:documentation>Tumorreste (Residualtumor)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="P">
+                            <xs:annotation>
+                                <xs:documentation>Tumorreste (Residualtumor) Progress</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="N">
+                            <xs:annotation>
+                                <xs:documentation>Tumorreste (Residualtumor) No Change</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="R">
+                            <xs:annotation>
+                                <xs:documentation>Lokalrezidiv</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="F">
+                            <xs:annotation>
+                                <xs:documentation>fraglicher Befund</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="X">
+                            <xs:annotation>
+                                <xs:documentation>fehlende Angabe</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Verlauf_Tumorstatus_Lymphknoten" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Beurteilung der Situation im Bereich der regionären Lymphknoten
+                        Hinweis:
+                        T = bekannter Lymphknotenbefall Residuen, unbekannt, ob Progress oder No Change
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="K">
+                            <xs:annotation>
+                                <xs:documentation>kein Lymphknotenbefall nachweisbar</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="T">
+                            <xs:annotation>
+                                <xs:documentation>bekannter Lymphknotenbefall Residuen</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="P">
+                            <xs:annotation>
+                                <xs:documentation>bekannter Lymphknotenbefall Progress</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="N">
+                            <xs:annotation>
+                                <xs:documentation>bekannter Lymphknotenbefall No Change</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="R">
+                            <xs:annotation>
+                                <xs:documentation>neu aufgetretenes Lymphknotenrezidiv</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="F">
+                            <xs:annotation>
+                                <xs:documentation>fraglicher Befund</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="X">
+                            <xs:annotation>
+                                <xs:documentation>fehlende Angabe</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Verlauf_Tumorstatus_Fernmetastasen" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Beurteilung der Situation im Bereich der Fernmetastasen
+                        Hinweis:
+                        R= Neu aufgetretene Fernmetastase(n) bzw. Metastasenrezidivbeschriebt eine Situation, in der zuvor Metastatsenfreiheit bestanden hat
+                        oder durch Therapie erreicht wurde.Neue Metastasen auch unter "Fernmetastasen" mit Lokalisation und Datum übermitteln.
+                        P= Wenn zu bestehenden Fernmetastasen neue hinzukommen. Bei einem klinisch divergenten Geschehen, ist die prognostisch ungünstigere Ausprägung zu übermitteln.
+                        Neue Metastasen auch unter "Fernmetastasen" mit Lokalisation und Datum übermitteln.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="K">
+                            <xs:annotation>
+                                <xs:documentation>keine Fernmetastasen nachweisbar</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="T">
+                            <xs:annotation>
+                                <xs:documentation>Fernmetastasenl Residuen</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="P">
+                            <xs:annotation>
+                                <xs:documentation>Fernmetastasen Progress</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="N">
+                            <xs:annotation>
+                                <xs:documentation>Fernmetastasen No Change</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="R">
+                            <xs:annotation>
+                                <xs:documentation>neu aufgetretene Fernmetastase(n) bzw. Metastasenrezidiv</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="F">
+                            <xs:annotation>
+                                <xs:documentation>fraglicher Befund</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="U">
+                            <xs:annotation>
+                                <xs:documentation>unbekannt</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="X">
+                            <xs:annotation>
+                                <xs:documentation>fehlende Angabe</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Menge_FM" type="Menge_FM_Typ" minOccurs="0"/>
+            <xs:element name="Histologie" type="Histologie_Typ" minOccurs="0"/>
+            <xs:element name="TNM" type="TNM_Typ" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Menge_Weitere_Klassifikation" type="Menge_Weitere_Klassifikation_Typ" minOccurs="0"/>
+            <xs:element name="Menge_Genetik" type="Menge_Genetik_Typ" minOccurs="0"/>
+            <xs:element name="Allgemeiner_Leistungszustand" type="Allgemeiner_Leistungszustand_Typ"/>
+            <xs:element name="Modul_Allgemein" type="Modul_Allgemein_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Mamma" type="Modul_Mamma_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Darm" type="Modul_Darm_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Prostata" type="Modul_Prostata_Typ" minOccurs="0"/>
+            <xs:element name="Modul_Malignes_Melanom" type="Modul_Malignes_Melanom_Typ" minOccurs="0"/>
+            <xs:element name="Modul_DKKR" type="Modul_DKKR_Typ" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="Verlauf_ID" type="FreitextID_Typ" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="Tod_Typ">
+        <xs:sequence>
+            <xs:element name="Sterbedatum" type="Datum_Tag_genau_Typ"/>
+            <xs:element name="Tod_tumorbedingt" type="JNU_Typ">
+                <xs:annotation>
+                    <xs:documentation>Krebs-Tod-Relation</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Menge_Todesursachen" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Todesursache_ICD" type="Allgemein_ICD_Typ" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Modul_DKKR" type="Modul_DKKR_Typ" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="Abschluss_ID" type="FreitextID_Typ" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="Tumorkonferenz_Typ">
+        <xs:annotation>
+            <xs:documentation>
+                Hier werden Tumorkonferenzen und andere Therapieplanungen außerhalb von Tumorkonferenzen hinterlegt
+                Neu in oBDS 3.0.0 ist die Dokumentation der festgelegten Therapieschritte
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Meldeanlass">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="diagnose"/>
+                        <xs:enumeration value="behandlungsbeginn"/>
+                        <xs:enumeration value="behandlungsende"/>
+                        <xs:enumeration value="statusaenderung"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Datum" type="Datum_Tag_oder_Monat_oder_Jahr_oder_nicht_genau_Typ"/>
+            <xs:element name="Typ">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="praeth">
+                            <xs:annotation>
+                                <xs:documentation>prätherapeutische Tumorkonferenz (Festlegung der Therapiestrategie)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="postop">
+                            <xs:annotation>
+                                <xs:documentation>postoperative Tumorkonferenz (Planung der postoperativen Therapie, z. B. zur Frage adjuvante Therapie)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="postth">
+                            <xs:annotation>
+                                <xs:documentation>posttherapeutische Tumorkonferenz (manche Tumoren werden nicht operiert)</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="ther">
+                            <xs:annotation>
+                                <xs:documentation>Therapieplanung ohne Tumorkonferenz</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="Therapieempfehlung" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Menge_Typ_Therapieempfehlung">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="Typ_Therapieempfehlung" maxOccurs="unbounded">
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:enumeration value="CH">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Chemotherapie</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="HO">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Hormontherapie</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="IM">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Immun-/Antikörpertherapie</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="ZS">
+                                                    <xs:annotation>
+                                                        <xs:documentation>zielgerichtete Substanzen</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="SZ">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Stammzelltransplantation (inkl. Knochenmarktransplantation)</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="CI">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Chemo- + Immun-/Antikörpertherapie</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="CZ">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Chemotherapie + zielgerichtete Substanzen</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="CIZ">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Chemo- + Immun-/Antikörpertherapie + zielgerichtete Substanzen</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="IZ">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Immun-/Antikörpertherapie + zielgerichtete Substanzen</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="WW">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Watchful Waiting</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="AS">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Active Surveillance</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="WS">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Wait and see</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="OP">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Operation</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="ST">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Strahlentherapie</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="SO">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Sonstiges</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                                <xs:enumeration value="KW">
+                                                    <xs:annotation>
+                                                        <xs:documentation>keine weitere tumorspezifische Therapie empfohlen</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:enumeration>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="Abweichung_Patientenwunsch" type="JNU_Typ"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="Tumorkonferenz_ID" type="FreitextID_Typ" use="optional"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/test/java/de/basisdatensatz/obds/v3/ObdsDeserialisationTest.java
+++ b/src/test/java/de/basisdatensatz/obds/v3/ObdsDeserialisationTest.java
@@ -1,4 +1,4 @@
-package de.basisdatensatz.obds3;
+package de.basisdatensatz.obds.v3;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/de/basisdatensatz/obds3/ObdsDeserialisationTest.java
+++ b/src/test/java/de/basisdatensatz/obds3/ObdsDeserialisationTest.java
@@ -12,17 +12,25 @@ public class ObdsDeserialisationTest {
 
   @Test
   void testShouldDeserializeObds3() throws IOException {
-    var resource = this.getClass().getClassLoader().getResource("obds3/test1.xml");
-    var xmlMapper =
+    final var resource = this.getClass().getClassLoader().getResource("obds3/test1.xml");
+    final var xmlMapper =
         XmlMapper.builder()
             .defaultUseWrapper(false)
             .addModule(new JakartaXmlBindAnnotationModule())
             .addModule(new Jdk8Module())
             .build();
 
-    var actual = xmlMapper.readValue(resource.openStream(), OBDS.class);
+    final var actual = xmlMapper.readValue(resource.openStream(), OBDS.class);
 
     assertThat(actual).isInstanceOf(OBDS.class);
-    assertThat(actual.mengePatient.getPatient().get(0).patientID).isEqualTo("00001234");
+    assertThat(actual.getMengePatient().getPatient()).hasSize(1);
+
+    final var patient = actual.getMengePatient().getPatient().getFirst();
+    assertThat(patient).isInstanceOf(OBDS.MengePatient.Patient.class);
+    assertThat(patient.getMengeMeldung().getMeldung()).hasSize(1);
+
+    final var meldung = patient.getMengeMeldung().getMeldung().getFirst();
+    assertThat(meldung).isInstanceOf(OBDS.MengePatient.Patient.MengeMeldung.Meldung.class);
+    assertThat(meldung.getTumorzuordnung()).isInstanceOf(TumorzuordnungTyp.class);
   }
 }

--- a/src/test/java/de/basisdatensatz/obds3/ObdsDeserialisationTest.java
+++ b/src/test/java/de/basisdatensatz/obds3/ObdsDeserialisationTest.java
@@ -1,0 +1,28 @@
+package de.basisdatensatz.obds3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class ObdsDeserialisationTest {
+
+  @Test
+  void testShouldDeserializeObds3() throws IOException {
+    var resource = this.getClass().getClassLoader().getResource("obds3/test1.xml");
+    var xmlMapper =
+        XmlMapper.builder()
+            .defaultUseWrapper(false)
+            .addModule(new JakartaXmlBindAnnotationModule())
+            .addModule(new Jdk8Module())
+            .build();
+
+    var actual = xmlMapper.readValue(resource.openStream(), OBDS.class);
+
+    assertThat(actual).isInstanceOf(OBDS.class);
+    assertThat(actual.mengePatient.getPatient().get(0).patientID).isEqualTo("00001234");
+  }
+}

--- a/src/test/resources/obds3/test1.xml
+++ b/src/test/resources/obds3/test1.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<oBDS xmlns="http://www.basisdatensatz.de/oBDS/XML" Schema_Version="3.0.2">
+    <Absender Absender_ID="TEST" Software_ID="ONKOSTAR" Software_Version="2.13.1">
+        <Bezeichnung>TEST</Bezeichnung>
+        <Anschrift>Musterstraße 1, 012345 Musterhausen</Anschrift>
+    </Absender>
+    <Meldedatum>2024-06-11</Meldedatum>
+    <Menge_Patient>
+        <Patient Patient_ID="00001234">
+            <Patienten_Stammdaten>
+                <Versichertendaten_GKV>
+                    <IKNR>103456789</IKNR>
+                    <GKV_Versichertennummer>E123456789</GKV_Versichertennummer>
+                </Versichertendaten_GKV>
+                <Nachname>Tester</Nachname>
+                <Vornamen>Patrick</Vornamen>
+                <Geschlecht>M</Geschlecht>
+                <Geburtsdatum Datumsgenauigkeit="T">1980-01-01</Geburtsdatum>
+                <Adresse>
+                    <Strasse>Testweg</Strasse>
+                    <Hausnummer>1</Hausnummer>
+                    <Land>DE</Land>
+                    <PLZ>01234</PLZ>
+                    <Ort>Musterhausen</Ort>
+                </Adresse>
+            </Patienten_Stammdaten>
+            <Menge_Meldung>
+                <Meldung Meldung_ID="TEST1727528" Melder_ID="TEST">
+                    <Meldebegruendung>I</Meldebegruendung>
+                    <Eigene_Leistung>J</Eigene_Leistung>
+                    <Tumorzuordnung Tumor_ID="1">
+                        <Primaertumor_ICD>
+                            <Code>C17.1</Code>
+                            <Version>10 2015 GM</Version>
+                        </Primaertumor_ICD>
+                        <Diagnosedatum Datumsgenauigkeit="T">2024-06-10</Diagnosedatum>
+                    </Tumorzuordnung>
+                    <Diagnose>
+                        <Diagnosesicherung>1</Diagnosesicherung>
+                        <Allgemeiner_Leistungszustand>0</Allgemeiner_Leistungszustand>
+                    </Diagnose>
+                </Meldung>
+            </Menge_Meldung>
+        </Patient>
+    </Menge_Patient>
+    <Menge_Melder>
+        <Melder ID="TEST">
+            <Ident_Nummern>
+                <IKNR>103456789</IKNR>
+            </Ident_Nummern>
+        </Melder>
+    </Menge_Melder>
+</oBDS>


### PR DESCRIPTION
This generates model classes for oBDS schema version 3.0.2 based on related XSD file using JAXB.

Jackson XML mapper is used with Jakarta XMLBind annotation module to support Jakarta XML annotations.

closes  #61 