### PR TITLE
chore: log if deceased is NULL

### DIFF
--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsPatientMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsPatientMapper.java
@@ -157,7 +157,11 @@ public class ObdsPatientMapper extends ObdsToFhirMapper {
                 .getTod()
                 .getSterbedatum();
 
-        patient.setDeceased(convertObdsDateToDateTimeType(deathDate));
+        final var deceased = convertObdsDateToDateTimeType(deathDate);
+        if (null == deceased) {
+          LOG.warn("Sterbedatum is NULL.");
+        }
+        patient.setDeceased(deceased);
       } else {
         LOG.warn("Sterbedatum not set on any of the Tod Meldungen.");
       }


### PR DESCRIPTION
This simply logs a warning if resulting deceased date ist NULL which is the result if "Sterbedatum" tag in oBDS is either not present or present but blank.

Further discussion:

Since the handling of empty or `null` date strings seems some kind of inconsistent, the following issue should be discussed: #104