### PR TITLE
feat: add XJC bindings file and config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,8 @@ tasks.register('xsd2java') {
 		ant.xjc(
 				destdir: "${jaxbTargetDir}",
 				package: 'de.basisdatensatz.obds.v3',
-				schema: 'src/main/resources/schema/oBDS_v3.0.3.xsd'
+				schema: 'src/main/resources/schema/oBDS_v3.0.3.xsd',
+				binding: 'src/main/resources/schema/oBDS_v3.0.3.bindings.xjb'
 		)
 
 	}

--- a/src/main/resources/schema/oBDS_v3.0.3.bindings.xjb
+++ b/src/main/resources/schema/oBDS_v3.0.3.bindings.xjb
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jaxb:bindings jaxb:version="3.0" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <jaxb:bindings schemaLocation="oBDS_v3.0.3.xsd">
+        <jaxb:bindings node="//xs:element[@name='Geschlecht']/xs:simpleType">
+            <jaxb:typesafeEnumClass name="Geschlecht" />
+        </jaxb:bindings>
+    </jaxb:bindings>
+</jaxb:bindings>


### PR DESCRIPTION
This adds example binding for anonymous oBDS 3 'Geschlecht' type, that should have related Java enum and should not be mapped to Java string.