### PR TITLE
refactor: multiple refacs in ConditionMapperTest

### DIFF
--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/ConditionMapperTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/ConditionMapperTest.java
@@ -12,6 +12,7 @@ import java.util.TimeZone;
 import org.approvaltests.Approvals;
 import org.approvaltests.core.Options;
 import org.hl7.fhir.r4.model.Reference;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.miracum.streams.ume.obdstofhir.FhirProperties;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,10 +22,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(classes = {FhirProperties.class})
 @EnableConfigurationProperties
 class ConditionMapperTest {
-  private final ConditionMapper sut;
 
-  @Autowired
-  ConditionMapperTest(FhirProperties fhirProps) {
+  private static ConditionMapper sut;
+
+  @BeforeAll
+  static void beforeEach(@Autowired FhirProperties fhirProps) {
     sut = new ConditionMapper(fhirProps);
   }
 

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/ConditionMapperTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/ConditionMapperTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 import de.basisdatensatz.obds.v3.OBDS;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.TimeZone;
 import org.approvaltests.Approvals;
 import org.approvaltests.core.Options;
@@ -41,6 +42,7 @@ class ConditionMapperTest {
     final var xmlMapper =
         XmlMapper.builder()
             .defaultUseWrapper(false)
+            .defaultDateFormat(new SimpleDateFormat("yyyy-MM-dd"))
             .addModule(new JakartaXmlBindAnnotationModule())
             .addModule(new Jdk8Module())
             .build();

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/ConditionMapperTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/ConditionMapperTest.java
@@ -13,7 +13,8 @@ import org.approvaltests.Approvals;
 import org.approvaltests.core.Options;
 import org.hl7.fhir.r4.model.Reference;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.miracum.streams.ume.obdstofhir.FhirProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -27,14 +28,14 @@ class ConditionMapperTest {
 
   @BeforeAll
   static void beforeEach(@Autowired FhirProperties fhirProps) {
+    TimeZone.setDefault(TimeZone.getTimeZone("Europe/Berlin"));
     sut = new ConditionMapper(fhirProps);
   }
 
-  @Test
-  void map_withGivenObds_shouldCreateValidConditionResource() throws IOException {
-    TimeZone.setDefault(TimeZone.getTimeZone("Europe/Berlin"));
-    // TODO: refactor to use a data provider for parameterized tests
-    final var resource = this.getClass().getClassLoader().getResource("obds3/test1.xml");
+  @ParameterizedTest
+  @CsvSource({"obds3/test1.xml"})
+  void map_withGivenObds_shouldCreateValidConditionResource(String sourceFile) throws IOException {
+    final var resource = this.getClass().getClassLoader().getResource(sourceFile);
     assertThat(resource).isNotNull();
 
     final var xmlMapper =

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.approved.fhir.json
@@ -12,5 +12,5 @@
   "subject": {
     "reference": "Patient/1"
   },
-  "recordedDate": "2024-06-10T02:00:00+02:00"
+  "recordedDate": "2024-06-10T00:00:00+02:00"
 }


### PR DESCRIPTION
There are three different refacs at once, each in its own commit:

* Use `@BeforeAll` to get rid of the use of test class constructors
* Changes to related ToDo statement: Use parameterized test
* Add default date format for oBDS (dates) to align resulting FHIR date to midnight