### PR TITLE
refactor: some refacs in PatientMapperTest

### DIFF
--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/PatientMapperTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/PatientMapperTest.java
@@ -8,8 +8,10 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 import de.basisdatensatz.obds.v3.OBDS;
 import java.io.IOException;
+import java.util.TimeZone;
 import org.approvaltests.Approvals;
 import org.approvaltests.core.Options;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.miracum.streams.ume.obdstofhir.FhirProperties;
@@ -20,10 +22,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(classes = {FhirProperties.class})
 @EnableConfigurationProperties
 class PatientMapperTest {
-  private final PatientMapper sut;
+  private static PatientMapper sut;
 
-  @Autowired
-  PatientMapperTest(FhirProperties fhirProps) {
+  @BeforeAll
+  static void beforeEach(@Autowired FhirProperties fhirProps) {
+    TimeZone.setDefault(TimeZone.getTimeZone("Europe/Berlin"));
     sut = new PatientMapper(fhirProps);
   }
 

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/PatientMapperTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/PatientMapperTest.java
@@ -1,7 +1,6 @@
 package org.miracum.streams.ume.obdstofhir.mapper.mii;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import ca.uhn.fhir.context.FhirContext;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
@@ -11,7 +10,8 @@ import de.basisdatensatz.obds.v3.OBDS;
 import java.io.IOException;
 import org.approvaltests.Approvals;
 import org.approvaltests.core.Options;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.miracum.streams.ume.obdstofhir.FhirProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -27,10 +27,10 @@ class PatientMapperTest {
     sut = new PatientMapper(fhirProps);
   }
 
-  @Test
-  void map_withGivenObds_shouldCreateValidPatientResource() throws IOException {
-    // TODO: refactor to use a data provider for parameterized tests
-    final var resource = this.getClass().getClassLoader().getResource("obds3/test1.xml");
+  @ParameterizedTest
+  @CsvSource({"obds3/test1.xml"})
+  void map_withGivenObds_shouldCreateValidPatientResource(String sourceFile) throws IOException {
+    final var resource = this.getClass().getClassLoader().getResource(sourceFile);
     assertThat(resource).isNotNull();
 
     final var xmlMapper =


### PR DESCRIPTION
This PR contains refacs as applied in #142 before

* Use @BeforeAll to get rid of the use of test class constructors
* Changes to related ToDo statement: Use parameterized test