### PR TITLE
test: fix parallel test run for default patient ID pattern

### DIFF
--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirIntegrationTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirIntegrationTest.java
@@ -40,6 +40,9 @@ public class ObdsToFhirIntegrationTest {
       "1234567890,123456789", // Max 9 digits, remove last digit '0'
       "1234567891,123456789", // Max 9 digits, remove last digit '1'
       "0000012345,0000012345", // Not mathching pattern - keep as is
+      "G1234,G1234", // Not mathching pattern - keep as is
+      "G123456,G123456", // Not matching pattern - keep as is
+      "G123456789,G12345678", // return Non-zero and 8 digits
     })
     void applyDefaultPattern(String input, String output) {
       var actual = ObdsToFhirMapper.convertId(input);

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapperTests.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapperTests.java
@@ -104,22 +104,6 @@ class ObdsToFhirMapperTests {
   }
 
   @ParameterizedTest
-  @CsvSource({
-    "12345,12345",
-    "123456789,123456789",
-    "1234567890,123456789", // Max 9 digits, remove last digit '0'
-    "1234567891,123456789", // Max 9 digits, remove last digit '1'
-    "0000012345,0000012345", // Not mathching pattern - keep as is
-    "G1234,G1234", // Not mathching pattern - keep as is
-    "G123456,G123456", // Not matching pattern - keep as is
-    "G123456789,G12345678", // return Non-zero and 8 digits
-  })
-  void convertPatientIdWithDefaultPattern(String input, String output) {
-    var actual = ObdsToFhirMapper.convertId(input);
-    assertThat(actual).isEqualTo(output);
-  }
-
-  @ParameterizedTest
   @MethodSource("icd10GmCodeValidationData")
   void checkValueToMatchIcd10Pattern(String input, boolean valid) {
     var actual = ObdsToFhirMapper.isIcd10GmCode(input);


### PR DESCRIPTION
Running tests in parallel and undefined order, the default PID pattern might have been overridden by another test. Since this is used static this might result in failed tests if tests from

* ObdsToFhirMapperTests
* ObdsToFhirIntegrationTest

are running in parallel.

To fix this, the test method within ObdsToFhirMapperTests has been removed and the missing test values, checking default pattern handling, have been added to the test values in ObdsToFhirIntegrationTest.