### PR TITLE
feat: map any AllgemeinerLeistungszustandTyp to ECOG

### DIFF
--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapper.java
@@ -2,6 +2,7 @@ package org.miracum.streams.ume.obdstofhir.mapper;
 
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import com.google.common.hash.Hashing;
+import de.basisdatensatz.obds.v3.AllgemeinerLeistungszustandTyp;
 import de.basisdatensatz.obds.v3.DatumTagOderMonatGenauTyp;
 import de.basisdatensatz.obds.v3.DatumTagOderMonatOderJahrOderNichtGenauTyp;
 import java.nio.charset.StandardCharsets;
@@ -316,5 +317,34 @@ public abstract class ObdsToFhirMapper {
     var date = new DateTimeType(obdsDatum.toGregorianCalendar().getTime());
     date.setPrecision(TemporalPrecisionEnum.DAY);
     return Optional.of(date);
+  }
+
+  /**
+   * Transforms AllgemeinerLeistungszustandTyp to another AllgemeinerLeistungszustandTyp using ECOG.
+   *
+   * @param value The value to be transformed
+   * @return Returns AllgemeinerLeistungszustandTyp for ECOG or U (unknown)
+   */
+  public static AllgemeinerLeistungszustandTyp allgemeinerLeistungszustandToEcog(
+      AllgemeinerLeistungszustandTyp value) {
+    switch (value) {
+      case AllgemeinerLeistungszustandTyp.KARNOFSKY_100:
+      case AllgemeinerLeistungszustandTyp.KARNOFSKY_90:
+        return AllgemeinerLeistungszustandTyp.ECOG_0;
+      case AllgemeinerLeistungszustandTyp.KARNOFSKY_80:
+      case AllgemeinerLeistungszustandTyp.KARNOFSKY_70:
+        return AllgemeinerLeistungszustandTyp.ECOG_1;
+      case AllgemeinerLeistungszustandTyp.KARNOFSKY_60:
+      case AllgemeinerLeistungszustandTyp.KARNOFSKY_50:
+        return AllgemeinerLeistungszustandTyp.ECOG_2;
+      case AllgemeinerLeistungszustandTyp.KARNOFSKY_40:
+      case AllgemeinerLeistungszustandTyp.KARNOFSKY_30:
+        return AllgemeinerLeistungszustandTyp.ECOG_3;
+      case AllgemeinerLeistungszustandTyp.KARNOFSKY_20:
+      case AllgemeinerLeistungszustandTyp.KARNOFSKY_10:
+        return AllgemeinerLeistungszustandTyp.ECOG_4;
+      default:
+        return value;
+    }
   }
 }

--- a/src/main/resources/schema/oBDS_v3.0.3.bindings.xjb
+++ b/src/main/resources/schema/oBDS_v3.0.3.bindings.xjb
@@ -37,5 +37,25 @@
         <jaxb:bindings node="//xs:complexType[@name='SYST_Typ']//xs:element[@name='Ende_Grund']/xs:simpleType">
             <jaxb:typesafeEnumClass name="EndeGrund" />
         </jaxb:bindings>
+        <jaxb:bindings node="//xs:simpleType[@name='Allgemeiner_Leistungszustand_Typ']">
+            <jaxb:typesafeEnumClass name="Allgemeiner_Leistungszustand_Typ">
+                <jaxb:typesafeEnumMember value="0" name="ECOG_0"/>
+                <jaxb:typesafeEnumMember value="1" name="ECOG_1"/>
+                <jaxb:typesafeEnumMember value="2" name="ECOG_2"/>
+                <jaxb:typesafeEnumMember value="3" name="ECOG_3"/>
+                <jaxb:typesafeEnumMember value="4" name="ECOG_4"/>
+                <jaxb:typesafeEnumMember value="U" name="U"/>
+                <jaxb:typesafeEnumMember value="10%" name="KARNOFSKY_10"/>
+                <jaxb:typesafeEnumMember value="20%" name="KARNOFSKY_20"/>
+                <jaxb:typesafeEnumMember value="30%" name="KARNOFSKY_30"/>
+                <jaxb:typesafeEnumMember value="40%" name="KARNOFSKY_40"/>
+                <jaxb:typesafeEnumMember value="50%" name="KARNOFSKY_50"/>
+                <jaxb:typesafeEnumMember value="60%" name="KARNOFSKY_60"/>
+                <jaxb:typesafeEnumMember value="70%" name="KARNOFSKY_70"/>
+                <jaxb:typesafeEnumMember value="80%" name="KARNOFSKY_80"/>
+                <jaxb:typesafeEnumMember value="90%" name="KARNOFSKY_90"/>
+                <jaxb:typesafeEnumMember value="100%" name="KARNOFSKY_100"/>
+            </jaxb:typesafeEnumClass>
+        </jaxb:bindings>
     </jaxb:bindings>
 </jaxb:bindings>

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapperTests.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapperTests.java
@@ -3,6 +3,7 @@ package org.miracum.streams.ume.obdstofhir.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import de.basisdatensatz.obds.v3.AllgemeinerLeistungszustandTyp;
 import de.basisdatensatz.obds.v3.DatumTagOderMonatGenauTyp;
 import de.basisdatensatz.obds.v3.DatumTagOderMonatGenauTyp.DatumsgenauigkeitTagOderMonatGenau;
 import de.basisdatensatz.obds.v3.DatumTagOderMonatOderJahrOderNichtGenauTyp;
@@ -223,5 +224,45 @@ class ObdsToFhirMapperTests {
     var actual = ObdsToFhirMapper.convertObdsDatumToDateType(datum);
 
     assertThat(actual.asStringValue()).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("allgemeinerLeistungszustandTestData")
+  void shouldMapAllegemeinerLeistungszustandToEcog(
+      AllgemeinerLeistungszustandTyp in, AllgemeinerLeistungszustandTyp expected) {
+    var actual = ObdsConditionMapper.allgemeinerLeistungszustandToEcog(in);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> allgemeinerLeistungszustandTestData() {
+    return Stream.of(
+        Arguments.of(
+            AllgemeinerLeistungszustandTyp.KARNOFSKY_100, AllgemeinerLeistungszustandTyp.ECOG_0),
+        Arguments.of(
+            AllgemeinerLeistungszustandTyp.KARNOFSKY_90, AllgemeinerLeistungszustandTyp.ECOG_0),
+        Arguments.of(
+            AllgemeinerLeistungszustandTyp.KARNOFSKY_80, AllgemeinerLeistungszustandTyp.ECOG_1),
+        Arguments.of(
+            AllgemeinerLeistungszustandTyp.KARNOFSKY_70, AllgemeinerLeistungszustandTyp.ECOG_1),
+        Arguments.of(
+            AllgemeinerLeistungszustandTyp.KARNOFSKY_60, AllgemeinerLeistungszustandTyp.ECOG_2),
+        Arguments.of(
+            AllgemeinerLeistungszustandTyp.KARNOFSKY_50, AllgemeinerLeistungszustandTyp.ECOG_2),
+        Arguments.of(
+            AllgemeinerLeistungszustandTyp.KARNOFSKY_40, AllgemeinerLeistungszustandTyp.ECOG_3),
+        Arguments.of(
+            AllgemeinerLeistungszustandTyp.KARNOFSKY_30, AllgemeinerLeistungszustandTyp.ECOG_3),
+        Arguments.of(
+            AllgemeinerLeistungszustandTyp.KARNOFSKY_20, AllgemeinerLeistungszustandTyp.ECOG_4),
+        Arguments.of(
+            AllgemeinerLeistungszustandTyp.KARNOFSKY_10, AllgemeinerLeistungszustandTyp.ECOG_4),
+        Arguments.of(
+            AllgemeinerLeistungszustandTyp.KARNOFSKY_40, AllgemeinerLeistungszustandTyp.ECOG_3),
+        Arguments.of(AllgemeinerLeistungszustandTyp.U, AllgemeinerLeistungszustandTyp.U),
+        Arguments.of(AllgemeinerLeistungszustandTyp.ECOG_0, AllgemeinerLeistungszustandTyp.ECOG_0),
+        Arguments.of(AllgemeinerLeistungszustandTyp.ECOG_1, AllgemeinerLeistungszustandTyp.ECOG_1),
+        Arguments.of(AllgemeinerLeistungszustandTyp.ECOG_2, AllgemeinerLeistungszustandTyp.ECOG_2),
+        Arguments.of(AllgemeinerLeistungszustandTyp.ECOG_3, AllgemeinerLeistungszustandTyp.ECOG_3),
+        Arguments.of(AllgemeinerLeistungszustandTyp.ECOG_4, AllgemeinerLeistungszustandTyp.ECOG_4));
   }
 }


### PR DESCRIPTION
This will transform a AllgemeinerLeistungszustandTyp to another AllgemeinerLeistungszustandTyp using ECOG related enum values or U (unknown).

This also provides oBDS 3 ECOG/Karnofsky/Unknown Enum for Java.