### PR TITLE
refactor: extract mapping Karnofsky to ECOG

### DIFF
--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapper.java
@@ -2,6 +2,7 @@ package org.miracum.streams.ume.obdstofhir.mapper;
 
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import com.google.common.hash.Hashing;
+import de.basisdatensatz.obds.v3.AllgemeinerLeistungszustand;
 import de.basisdatensatz.obds.v3.DatumTagOderMonatGenauTyp;
 import de.basisdatensatz.obds.v3.DatumTagOderMonatOderJahrOderNichtGenauTyp;
 import java.nio.charset.StandardCharsets;
@@ -304,5 +305,34 @@ public abstract class ObdsToFhirMapper {
     var date = new DateTimeType(obdsDatum.toGregorianCalendar().getTime());
     date.setPrecision(TemporalPrecisionEnum.DAY);
     return Optional.of(date);
+  }
+
+  /**
+   * Transforms AllgemeinerLeistungszustand to another AllgemeinerLeistungszustand using ECOG.
+   *
+   * @param value The value to be transformed
+   * @return Returns AllgemeinerLeistungszustand for ECOG or U (unknown)
+   */
+  public static AllgemeinerLeistungszustand allgemeinerLeistungszustandToEcog(
+      AllgemeinerLeistungszustand value) {
+    switch (value) {
+      case AllgemeinerLeistungszustand.KARNOFSKY_100:
+      case AllgemeinerLeistungszustand.KARNOFSKY_90:
+        return AllgemeinerLeistungszustand.ECOG_0;
+      case AllgemeinerLeistungszustand.KARNOFSKY_80:
+      case AllgemeinerLeistungszustand.KARNOFSKY_70:
+        return AllgemeinerLeistungszustand.ECOG_1;
+      case AllgemeinerLeistungszustand.KARNOFSKY_60:
+      case AllgemeinerLeistungszustand.KARNOFSKY_50:
+        return AllgemeinerLeistungszustand.ECOG_2;
+      case AllgemeinerLeistungszustand.KARNOFSKY_40:
+      case AllgemeinerLeistungszustand.KARNOFSKY_30:
+        return AllgemeinerLeistungszustand.ECOG_3;
+      case AllgemeinerLeistungszustand.KARNOFSKY_20:
+      case AllgemeinerLeistungszustand.KARNOFSKY_10:
+        return AllgemeinerLeistungszustand.ECOG_4;
+      default:
+        return value;
+    }
   }
 }

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/mii/LeistungszustandMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/mii/LeistungszustandMapper.java
@@ -53,44 +53,43 @@ public class LeistungszustandMapper extends ObdsToFhirMapper {
             .setSystem(fhirProperties.getSystems().getMiiCsOnkoAllgemeinerLeistungszustandEcog());
     AllgemeinerLeistungszustand allgemeinerLeistungszustand =
         meldung.getDiagnose().getAllgemeinerLeistungszustand();
-    switch (allgemeinerLeistungszustand) {
-      case ECOG_0, KARNOFSKY_90, KARNOFSKY_100:
+    switch (allgemeinerLeistungszustandToEcog(allgemeinerLeistungszustand)) {
+      case ECOG_0:
         value.setCode("0");
         value.setDisplay(
             "Normale, uneingeschränkte Aktivität wie vor der Erkrankung (90 - 100 % "
                 + "nach Karnofsky)");
         break;
-      case ECOG_1, KARNOFSKY_70, KARNOFSKY_80:
+      case ECOG_1:
         value.setCode("1");
         value.setDisplay(
             "Einschränkung bei körperlicher Anstrengung, aber gehfähig; leichte "
                 + "körperliche Arbeit bzw. Arbeit im Sitzen (z. B. leichte Hausarbeit oder Büroarbeit) "
                 + "möglich (70 - 80 % nach Karnofsky)");
         break;
-      case ECOG_2, KARNOFSKY_50, KARNOFSKY_60:
+      case ECOG_2:
         value.setCode("2");
         value.setDisplay(
             "Gehfähig, Selbstversorgung möglich, aber nicht arbeitsfähig; kann mehr "
                 + "als 50 % der Wachzeit aufstehen (50 - 60 % nach Karnofsky)");
         break;
-      case ECOG_3, KARNOFSKY_30, KARNOFSKY_40:
+      case ECOG_3:
         value.setCode("3");
         value.setDisplay(
             "Nur begrenzte Selbstversorgung möglich; ist 50 % oder mehr der Wachzeit"
                 + " an Bett oder Stuhl gebunden (30 40 % nach Karnofsky)");
         break;
-      case ECOG_4, KARNOFSKY_10, KARNOFSKY_20:
+      case ECOG_4:
         value.setCode("4");
         value.setDisplay(
             "Völlig pflegebedürftig, keinerlei Selbstversorgung möglich; völlig an "
                 + "Bett oder Stuhl gebunden (10 - 20 % nach Karnofsky)");
         break;
-      case ECOG_U:
+      case U:
+      default:
         value.setCode("U");
         value.setDisplay("Unbekannt");
         break;
-      default:
-        break; // TODO: is this even possible? mandatory in oBDS
     }
     observation.setValue(new CodeableConcept(value));
 

--- a/src/main/resources/schema/oBDS_v3.0.3.bindings.xjb
+++ b/src/main/resources/schema/oBDS_v3.0.3.bindings.xjb
@@ -32,7 +32,7 @@
                 <jaxb:typesafeEnumMember value="2" name="ECOG_2" />
                 <jaxb:typesafeEnumMember value="3" name="ECOG_3" />
                 <jaxb:typesafeEnumMember value="4" name="ECOG_4" />
-                <jaxb:typesafeEnumMember value="U" name="ECOG_U" />
+                <jaxb:typesafeEnumMember value="U" name="U" />
                 <jaxb:typesafeEnumMember value="10%" name="KARNOFSKY_10" />
                 <jaxb:typesafeEnumMember value="20%" name="KARNOFSKY_20" />
                 <jaxb:typesafeEnumMember value="30%" name="KARNOFSKY_30" />

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapperTests.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapperTests.java
@@ -3,6 +3,7 @@ package org.miracum.streams.ume.obdstofhir.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import de.basisdatensatz.obds.v3.AllgemeinerLeistungszustand;
 import de.basisdatensatz.obds.v3.DatumTagOderMonatGenauTyp;
 import de.basisdatensatz.obds.v3.DatumTagOderMonatGenauTyp.DatumsgenauigkeitTagOderMonatGenau;
 import java.time.DateTimeException;
@@ -198,5 +199,34 @@ class ObdsToFhirMapperTests {
     var actual = ObdsToFhirMapper.convertObdsDatumToDateTimeType((DatumTagOderMonatGenauTyp) null);
 
     assertThat(actual).isEmpty();
+  }
+
+  @ParameterizedTest
+  @MethodSource("allgemeinerLeistungszustandTestData")
+  void shouldMapAllegemeinerLeistungszustandToEcog(
+      AllgemeinerLeistungszustand in, AllgemeinerLeistungszustand expected) {
+    var actual = ObdsConditionMapper.allgemeinerLeistungszustandToEcog(in);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> allgemeinerLeistungszustandTestData() {
+    return Stream.of(
+        Arguments.of(AllgemeinerLeistungszustand.KARNOFSKY_100, AllgemeinerLeistungszustand.ECOG_0),
+        Arguments.of(AllgemeinerLeistungszustand.KARNOFSKY_90, AllgemeinerLeistungszustand.ECOG_0),
+        Arguments.of(AllgemeinerLeistungszustand.KARNOFSKY_80, AllgemeinerLeistungszustand.ECOG_1),
+        Arguments.of(AllgemeinerLeistungszustand.KARNOFSKY_70, AllgemeinerLeistungszustand.ECOG_1),
+        Arguments.of(AllgemeinerLeistungszustand.KARNOFSKY_60, AllgemeinerLeistungszustand.ECOG_2),
+        Arguments.of(AllgemeinerLeistungszustand.KARNOFSKY_50, AllgemeinerLeistungszustand.ECOG_2),
+        Arguments.of(AllgemeinerLeistungszustand.KARNOFSKY_40, AllgemeinerLeistungszustand.ECOG_3),
+        Arguments.of(AllgemeinerLeistungszustand.KARNOFSKY_30, AllgemeinerLeistungszustand.ECOG_3),
+        Arguments.of(AllgemeinerLeistungszustand.KARNOFSKY_20, AllgemeinerLeistungszustand.ECOG_4),
+        Arguments.of(AllgemeinerLeistungszustand.KARNOFSKY_10, AllgemeinerLeistungszustand.ECOG_4),
+        Arguments.of(AllgemeinerLeistungszustand.KARNOFSKY_40, AllgemeinerLeistungszustand.ECOG_3),
+        Arguments.of(AllgemeinerLeistungszustand.U, AllgemeinerLeistungszustand.U),
+        Arguments.of(AllgemeinerLeistungszustand.ECOG_0, AllgemeinerLeistungszustand.ECOG_0),
+        Arguments.of(AllgemeinerLeistungszustand.ECOG_1, AllgemeinerLeistungszustand.ECOG_1),
+        Arguments.of(AllgemeinerLeistungszustand.ECOG_2, AllgemeinerLeistungszustand.ECOG_2),
+        Arguments.of(AllgemeinerLeistungszustand.ECOG_3, AllgemeinerLeistungszustand.ECOG_3),
+        Arguments.of(AllgemeinerLeistungszustand.ECOG_4, AllgemeinerLeistungszustand.ECOG_4));
   }
 }


### PR DESCRIPTION
This also replaces `ECOG_U` with `U` in AllgemeinerLeistungszustand since it might be Karnofsky, ECOG or "unknown".

Based on #181.