### PR TITLE
feat: add procedure code/category to systemic therapy

### DIFF
--- a/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/obds/OPSTherapietypLookup.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/lookup/obds/OPSTherapietypLookup.java
@@ -1,0 +1,56 @@
+package org.miracum.streams.ume.obdstofhir.lookup.obds;
+
+import de.basisdatensatz.obds.v3.SYSTTyp.Therapieart;
+import java.util.HashMap;
+
+public class OPSTherapietypLookup {
+  private static final HashMap<Therapieart, OPS> lookup = new HashMap<>();
+
+  static {
+    lookup.put(
+        Therapieart.CH,
+        OPS.of("8-54", "Zytostatische Chemotherapie, Immuntherapie und antiretrovirale Therapie"));
+    lookup.put(Therapieart.HO, OPS.of("6-00", "Applikation von Medikamenten"));
+    lookup.put(
+        Therapieart.IM,
+        OPS.of("8-54", "Zytostatische Chemotherapie, Immuntherapie und antiretrovirale Therapie"));
+    lookup.put(
+        Therapieart.SZ,
+        OPS.of(
+            "8-86",
+            "Autogene und allogene Stammzelltherapie und lokale Therapie mit Blutbestandteilen und Hepatozyten"));
+    lookup.put(
+        Therapieart.CI,
+        OPS.of("8-54", "Zytostatische Chemotherapie, Immuntherapie und antiretrovirale Therapie"));
+  }
+
+  public static String lookupCode(Therapieart obdsCode) {
+    return lookup.get(obdsCode) != null ? lookup.get(obdsCode).getCode() : null;
+  }
+
+  public static String lookupDisplay(Therapieart obdsCode) {
+    return lookup.get(obdsCode) != null ? lookup.get(obdsCode).getDisplay() : null;
+  }
+
+  private static class OPS {
+    private String code;
+    private String display;
+
+    private OPS(String code, String display) {
+      this.code = code;
+      this.display = display;
+    }
+
+    public static OPS of(String code, String display) {
+      return new OPS(code, display);
+    }
+
+    public String getCode() {
+      return this.code;
+    }
+
+    public String getDisplay() {
+      return this.display;
+    }
+  }
+}

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/SystemischeTherapieProcedureMapperTest.map_withGivenObds_shouldCreateValidProcedure.Testpatient_1.xml.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/SystemischeTherapieProcedureMapperTest.map_withGivenObds_shouldCreateValidProcedure.Testpatient_1.xml.approved.fhir.json
@@ -21,23 +21,13 @@
   "category": {
     "coding": [ {
       "system": "http://snomed.info/sct",
-      "_code": {
-        "extension": [ {
-          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-          "valueCode": "unknown"
-        } ]
-      }
+      "code": "18629005"
     } ]
   },
   "code": {
     "coding": [ {
       "system": "http://fhir.de/CodeSystem/bfarm/ops",
-      "_code": {
-        "extension": [ {
-          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-          "valueCode": "unknown"
-        } ]
-      }
+      "code": "8-54"
     }, {
       "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-therapie-typ",
       "code": "IM"

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/SystemischeTherapieProcedureMapperTest.map_withGivenObds_shouldCreateValidProcedure.Testpatient_2.xml.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/SystemischeTherapieProcedureMapperTest.map_withGivenObds_shouldCreateValidProcedure.Testpatient_2.xml.approved.fhir.json
@@ -21,23 +21,13 @@
   "category": {
     "coding": [ {
       "system": "http://snomed.info/sct",
-      "_code": {
-        "extension": [ {
-          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-          "valueCode": "unknown"
-        } ]
-      }
+      "code": "18629005"
     } ]
   },
   "code": {
     "coding": [ {
       "system": "http://fhir.de/CodeSystem/bfarm/ops",
-      "_code": {
-        "extension": [ {
-          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-          "valueCode": "unknown"
-        } ]
-      }
+      "code": "6-00"
     }, {
       "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-therapie-typ",
       "code": "HO"

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/SystemischeTherapieProcedureMapperTest.map_withGivenObds_shouldCreateValidProcedure.Testpatient_3.xml.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/SystemischeTherapieProcedureMapperTest.map_withGivenObds_shouldCreateValidProcedure.Testpatient_3.xml.approved.fhir.json
@@ -21,23 +21,13 @@
   "category": {
     "coding": [ {
       "system": "http://snomed.info/sct",
-      "_code": {
-        "extension": [ {
-          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-          "valueCode": "unknown"
-        } ]
-      }
+      "code": "18629005"
     } ]
   },
   "code": {
     "coding": [ {
       "system": "http://fhir.de/CodeSystem/bfarm/ops",
-      "_code": {
-        "extension": [ {
-          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-          "valueCode": "unknown"
-        } ]
-      }
+      "code": "8-54"
     }, {
       "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-therapie-typ",
       "code": "CH"


### PR DESCRIPTION
This adds depending on result of `getTherapieart()` (if available):

* `code.coding.code`: Use OPS Code from `OPSTherapietypLookup` or SnomedCT from `SnomedCtTherapietypLook` for `WW`/`WS`/`AS`
* `category.coding.code`: Use SnomedCt `18629005` or a data absent code for `WW`/`WS`/`AS`

If `getTherapieart()` returns `null`, a data absent code will be used.

Since no dosage is known, `HO` will use OPS Code `6-00` (see: https://klassifikationen.bfarm.de/ops/kode-suche/htmlops2025/block-6-00...6-00.htm)