### PR TITLE
refactor: add fluent API for verification

### DIFF
--- a/src/test/java/org/miracum/streams/ume/obdstofhir/Verification.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/Verification.java
@@ -1,0 +1,149 @@
+package org.miracum.streams.ume.obdstofhir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ca.uhn.fhir.context.FhirContext;
+import java.util.List;
+import org.apache.commons.lang3.NotImplementedException;
+import org.approvaltests.Approvals;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+/** Entry point for verification methods. */
+public abstract class Verification {
+  protected int resourceSize = 0;
+
+  /**
+   * Creates a new instance of <code>{@link SingleVerification}</code>.
+   *
+   * @param <T> the resource type to be verified
+   * @param resource the resource to be verified
+   * @return the created verification object
+   */
+  public static <T extends IBaseResource> SingleVerification<T> verifyThat(T resource) {
+    return new SingleVerification<T>(resource);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link ListVerification}</code>.
+   *
+   * @param <T> the resources type to be verified
+   * @param resources the resources to be verified
+   * @return the created verification object
+   */
+  public static <T extends IBaseResource> ListVerification<T> verifyThat(List<T> resources) {
+    return new ListVerification<T>(resources);
+  }
+
+  /**
+   * Returns the verification to write more readable Verifications.
+   *
+   * @return the current verification object.
+   */
+  public Verification and() {
+    return this;
+  }
+
+  /**
+   * Verifies the current verification object to apply to the expected number of resources.
+   *
+   * @return the current verification object.
+   */
+  public Verification hasSize(int n) {
+    assertThat(resourceSize)
+        .as("Failed to assert that %d resources matches expected %d resources", n, resourceSize)
+        .isEqualTo(n);
+    return this;
+  }
+
+  /**
+   * Verifies the current verification object does not apply to any resources.
+   *
+   * @return the current verification object.
+   */
+  public Verification isEmpty() {
+    assertThat(resourceSize)
+        .as("Failed to assert that given resources are empty:  Found %d resources", resourceSize)
+        .isZero();
+    return this;
+  }
+
+  /**
+   * Verifies the current verification object does apply to some resources.
+   *
+   * @return the current verification object.
+   */
+  public Verification isNotEmpty() {
+    assertThat(resourceSize).as("Failed to assert that given resources are not empty").isNotZero();
+    return this;
+  }
+
+  /**
+   * Verifies the current verification object is <code>{@link ListVerification}</code> and n-th
+   * element matches approved source file
+   *
+   * @param sourceFile The approved source file
+   * @return the current verification object.
+   */
+  public Verification nthMatches(int n, String sourceFile) {
+    throw new NotImplementedException("Not implemented for single element verification");
+  }
+
+  /**
+   * Verifies the current verification object matches approved source file
+   *
+   * @param sourceFile The approved source file
+   * @return the current verification object.
+   */
+  public abstract Verification matches(String sourceFile);
+
+  public static class SingleVerification<T extends IBaseResource> extends Verification {
+
+    private T resource;
+
+    public SingleVerification(T resource) {
+      this.resourceSize = 1;
+      this.resource = resource;
+    }
+
+    public SingleVerification<T> matches(String sourceFile) {
+      var fhirParser = FhirContext.forR4().newJsonParser().setPrettyPrint(true);
+      var fhirJson = fhirParser.encodeResourceToString(resource);
+      Approvals.verify(
+          fhirJson,
+          Approvals.NAMES.withParameters(sourceFile).forFile().withExtension(".fhir.json"));
+      return this;
+    }
+  }
+
+  public static class ListVerification<T extends IBaseResource> extends Verification {
+
+    private List<T> resources;
+
+    public ListVerification(List<T> resources) {
+      this.resourceSize = resources.size();
+      this.resources = resources;
+    }
+
+    @Override
+    public ListVerification<T> nthMatches(int n, String sourceFile) {
+      assertThat(resources).hasSizeGreaterThan(n);
+      verifyThat(resources.get(n)).matches(sourceFile);
+      return this;
+    }
+
+    public ListVerification<T> matches(String sourceFile) {
+      for (int i = 0; i < resources.size(); i++) {
+        assertThat(resources.get(i)).isNotNull();
+        var fhirParser = FhirContext.forR4().newJsonParser().setPrettyPrint(true);
+        var fhirJson = fhirParser.encodeResourceToString(resources.get(i));
+        Approvals.verify(
+            fhirJson,
+            Approvals.NAMES
+                .withParameters(sourceFile, String.format("index_%d", i))
+                .forFile()
+                .withExtension(".fhir.json"));
+      }
+      return this;
+    }
+  }
+}

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/Verification.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/Verification.java
@@ -105,6 +105,7 @@ public abstract class Verification {
       this.resource = resource;
     }
 
+    @Override
     public SingleVerification<T> matches(String sourceFile) {
       var fhirParser = FhirContext.forR4().newJsonParser().setPrettyPrint(true);
       var fhirJson = fhirParser.encodeResourceToString(resource);
@@ -131,6 +132,7 @@ public abstract class Verification {
       return this;
     }
 
+    @Override
     public ListVerification<T> matches(String sourceFile) {
       for (int i = 0; i < resources.size(); i++) {
         assertThat(resources.get(i)).isNotNull();

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/ConditionMapperTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/ConditionMapperTest.java
@@ -1,6 +1,7 @@
 package org.miracum.streams.ume.obdstofhir.mapper.mii;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.miracum.streams.ume.obdstofhir.Verification.verifyThat;
 
 import de.basisdatensatz.obds.v3.OBDS;
 import java.io.IOException;
@@ -43,6 +44,6 @@ class ConditionMapperTest extends MapperTest {
 
     final var condition = sut.map(conMeldung, new Reference("Patient/1"), obds.getMeldedatum());
 
-    verify(condition, sourceFile);
+    verifyThat(condition).matches(sourceFile);
   }
 }

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/MapperTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/MapperTest.java
@@ -1,15 +1,13 @@
 package org.miracum.streams.ume.obdstofhir.mapper.mii;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.miracum.streams.ume.obdstofhir.Verification.verifyThat;
 
-import ca.uhn.fhir.context.FhirContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 import java.text.SimpleDateFormat;
 import java.util.List;
-import org.approvaltests.Approvals;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
 /** Abstract class to provide common methods for mapping tests */
@@ -37,10 +35,7 @@ public abstract class MapperTest {
    * @param sourceFile The approved source file
    */
   protected static void verify(IBaseResource resource, String sourceFile) {
-    var fhirParser = FhirContext.forR4().newJsonParser().setPrettyPrint(true);
-    var fhirJson = fhirParser.encodeResourceToString(resource);
-    Approvals.verify(
-        fhirJson, Approvals.NAMES.withParameters(sourceFile).forFile().withExtension(".fhir.json"));
+    verifyThat(resource).matches(sourceFile);
   }
 
   /**
@@ -50,16 +45,6 @@ public abstract class MapperTest {
    * @param sourceFile The approved source file
    */
   protected static <T extends IBaseResource> void verifyAll(List<T> resources, String sourceFile) {
-    for (int i = 0; i < resources.size(); i++) {
-      assertThat(resources.get(i)).isNotNull();
-      var fhirParser = FhirContext.forR4().newJsonParser().setPrettyPrint(true);
-      var fhirJson = fhirParser.encodeResourceToString(resources.get(i));
-      Approvals.verify(
-          fhirJson,
-          Approvals.NAMES
-              .withParameters(sourceFile, String.format("index_%d", i))
-              .forFile()
-              .withExtension(".fhir.json"));
-    }
+    verifyThat(resources).matches(sourceFile);
   }
 }

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/OperationMapperTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/OperationMapperTest.java
@@ -1,6 +1,7 @@
 package org.miracum.streams.ume.obdstofhir.mapper.mii;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.miracum.streams.ume.obdstofhir.Verification.verifyThat;
 
 import de.basisdatensatz.obds.v3.OBDS;
 import java.io.IOException;
@@ -53,10 +54,9 @@ class OperationMapperTest extends MapperTest {
     // Map and get the list of procedures
     final var resultResources = sut.map(opMeldung.getOP(), subject, condition);
 
-    assertThat(resultResources).isNotEmpty();
     LOG.info("Length of resultResources {}", resultResources.size());
     LOG.info("Number of OPS codes: {}", opMeldung);
 
-    verifyAll(resultResources, sourceFile);
+    verifyThat(resultResources).isNotEmpty().and().matches(sourceFile);
   }
 }

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/SystemischeTherapieMedicationStatementMapperTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/SystemischeTherapieMedicationStatementMapperTest.java
@@ -1,6 +1,7 @@
 package org.miracum.streams.ume.obdstofhir.mapper.mii;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.miracum.streams.ume.obdstofhir.Verification.verifyThat;
 
 import de.basisdatensatz.obds.v3.OBDS;
 import java.io.IOException;
@@ -43,8 +44,6 @@ class SystemischeTherapieMedicationStatementMapperTest extends MapperTest {
             .get();
     var list = sut.map(systMeldung.getSYST(), patient, procedure);
 
-    assertThat(list).hasSize(1);
-
-    verify(list.get(0), sourceFile);
+    verifyThat(list).hasSize(1).and().nthMatches(0, sourceFile);
   }
 }


### PR DESCRIPTION
Nur als Vorschlag gedacht.

Mit einer fluent API könnten die Tests nach #207 noch etwas "sprechender" werden, wenn es um die FHIR Ressourcen geht (https://martinfowler.com/bliki/FluentInterface.html).

```java
// Source File ist JSON Array
verifyThat(resultResources).isNotEmpty().and().matches(sourceFile);

// Source File ist JSON Object
verifyThat(resultResources).hasSize(1).and().nthMatches(0, sourceFile);
verifyThat(singleResource).matches(sourceFile);
```
als Alternative zu

```java
// Source File ist JSON Array
assertThat(resultResources).isNotEmpty();
verifyAll(resultResources,sourceFile);

// Source File ist JSON Object
assertThat(resultResources).hasSize(1);
verify(resultResources.get(0), sourceFile);
//--
verify(singleResource, sourceFile);
```

Die neuen (statischen) Methoden `verify(..)` und `verifyAll(..)` aus #207 sind da weniger "sprechend" und würden einfach an `verifyThat(..).matches(..)` delegieren.