### PR TITLE
ci: try inflating ValueSets before validation

### DIFF
--- a/.github/workflows/validate-fhir-resources.yaml
+++ b/.github/workflows/validate-fhir-resources.yaml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Restore FHIR package dependencies
         run: |
+          fhir config inflate ValueSets
           fhir restore
 
       - name: Validate generated FHIR resources

--- a/.github/workflows/validate-fhir-resources.yaml
+++ b/.github/workflows/validate-fhir-resources.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Restore FHIR package dependencies
         run: |
-          fhir config inflate ValueSets
+          fhir config inflate All
           fhir restore
 
       - name: Validate generated FHIR resources


### PR DESCRIPTION
Löst zumindest den ConditionMapper-validierungs-Fehler:

Alt: https://github.com/bzkf/obds-to-fhir/actions/runs/13196439372/job/36838725509#step:8:30 

```
(error: Code '8140/3' from system 'http://terminology.hl7.org/CodeSystem/icd-o-3' does not exist in the value set 'MII VS Onkologie Histology Morphology Behavior ICDO3' (https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/ValueSet/mii-vs-onko-histology-morphology-behavior-icdo3)) 
```

Neu: https://github.com/bzkf/obds-to-fhir/actions/runs/13284456498/job/37089914413

```
warning: Terminology service failed while validating code '8010/3' (system 'http://terminology.hl7.org/CodeSystem/icd-o-3'): Operation validate code failed: creating the required expansion failed mith message "CodeSystem `[http://terminology.hl7.org/CodeSystem/icd-o-3`](http://terminology.hl7.org/CodeSystem/icd-o-3%60) is marked incomplete, so the defined filter(s) cannot be applied.".
```