### PR TITLE
fix: use MII CodeSystem for CTCAE

### DIFF
--- a/src/main/java/org/miracum/streams/ume/obdstofhir/FhirProperties.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/FhirProperties.java
@@ -103,7 +103,7 @@ public class FhirProperties {
     private String miiCsOnkoAllgemeinerLeistungszustandEcog;
     private String histologiebefundDiagnosticReportId;
     private String nebenwirkungAdverseEventId;
-    private String miiVsOnkoNebenwirkungCtcaeGrad;
+    private String miiCsOnkoNebenwirkungCtcaeGrad;
     private String meddra;
   }
 

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/mii/NebenwirkungMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/mii/NebenwirkungMapper.java
@@ -9,13 +9,11 @@ import org.miracum.streams.ume.obdstofhir.FhirProperties;
 import org.miracum.streams.ume.obdstofhir.mapper.ObdsToFhirMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 public class NebenwirkungMapper extends ObdsToFhirMapper {
 
   private static final Logger LOG = LoggerFactory.getLogger(NebenwirkungMapper.class);
 
-  @Autowired
   public NebenwirkungMapper(FhirProperties fhirProperties) {
     super(fhirProperties);
   }
@@ -82,7 +80,7 @@ public class NebenwirkungMapper extends ObdsToFhirMapper {
         var seriousness =
             new CodeableConcept(
                 new Coding()
-                    .setSystem(fhirProperties.getSystems().getCtcaeGrading())
+                    .setSystem(fhirProperties.getSystems().getMiiCsOnkoNebenwirkungCtcaeGrad())
                     .setCode(nebenwirkung.getMengeNebenwirkung().getNebenwirkung().get(i).getGrad())
                     .setDisplay(""));
         adverseEvent.setSeriousness(seriousness);
@@ -109,7 +107,7 @@ public class NebenwirkungMapper extends ObdsToFhirMapper {
     var seriousness =
         new CodeableConcept(
             new Coding()
-                .setSystem(fhirProperties.getSystems().getCtcaeGrading())
+                .setSystem(fhirProperties.getSystems().getMiiCsOnkoNebenwirkungCtcaeGrad())
                 .setCode(nebenwirkung.getGradMaximal2OderUnbekannt())
                 .setDisplay(""));
     adverseEvent.setSeriousness(seriousness);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,7 +90,7 @@ fhir:
     observationCategory: "http://terminology.hl7.org/CodeSystem/observation-category"
     mii-cs-onko-grading: "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-grading"
     mii-cs-onko-allgemeiner-leistungszustand-ecog: "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-allgemeiner-leistungszustand-ecog"
-    mii-vs-onko-nebenwirkung-ctcae-grad: "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-vs-onko-nebenwirkung-ctcae-grad"
+    mii-cs-onko-nebenwirkung-ctcae-grad: "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-nebenwirkung-ctcae-grad"
     meddra: "https://www.meddra.org"
 
   profiles:

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/NebenwirkungMapperTest.map_withGivenObds_shouldCreateValidAdverseEvent.Testpatient_1.xml.index_0.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/NebenwirkungMapperTest.map_withGivenObds_shouldCreateValidAdverseEvent.Testpatient_1.xml.index_0.approved.fhir.json
@@ -21,7 +21,7 @@
   },
   "seriousness": {
     "coding": [ {
-      "system": "http://hl7.org/fhir/us/ctcae/CodeSystem/ctcae-grade-code-system",
+      "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-nebenwirkung-ctcae-grad",
       "code": "5"
     } ]
   },

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/NebenwirkungMapperTest.map_withGivenObds_shouldCreateValidAdverseEvent.Testpatient_2.xml.index_0.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/NebenwirkungMapperTest.map_withGivenObds_shouldCreateValidAdverseEvent.Testpatient_2.xml.index_0.approved.fhir.json
@@ -14,7 +14,7 @@
   },
   "seriousness": {
     "coding": [ {
-      "system": "http://hl7.org/fhir/us/ctcae/CodeSystem/ctcae-grade-code-system",
+      "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-nebenwirkung-ctcae-grad",
       "code": "U"
     } ]
   },

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/NebenwirkungMapperTest.map_withGivenObds_shouldCreateValidAdverseEvent.Testpatient_3.xml.index_0.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/NebenwirkungMapperTest.map_withGivenObds_shouldCreateValidAdverseEvent.Testpatient_3.xml.index_0.approved.fhir.json
@@ -14,7 +14,7 @@
   },
   "seriousness": {
     "coding": [ {
-      "system": "http://hl7.org/fhir/us/ctcae/CodeSystem/ctcae-grade-code-system",
+      "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-nebenwirkung-ctcae-grad",
       "code": "U"
     } ]
   },


### PR DESCRIPTION
Hatte es beim ursprünglichen Review übersehen, aber mir ist das "vs" aufgefallen, was dann https://github.com/medizininformatik-initiative/kerndatensatzmodul-onkologie/pull/150 getriggert hat. 

In dem https://fhir.org/guides/stats2/codesystem-hl7.fhir.us.ctcae-ctcae-grade-code-system.html system sind U und K keine validen codes also muss man ein eigenes nehmen (außer man mappt nochmal).