### PR TITLE
fix: missing FM for PathologieTyp & included meldungId in identifier

### DIFF
--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapper.java
@@ -117,7 +117,8 @@ public class ObdsToFhirBundleMapper extends ObdsToFhirMapper {
 
           if (diagnose.getMengeFM() != null && diagnose.getMengeFM().getFernmetastase() != null) {
             var diagnoseFM =
-                fernmetastasenMapper.map(diagnose, patientReference, primaryConditionReference);
+                fernmetastasenMapper.map(
+                    diagnose, meldung.getMeldungID(), patientReference, primaryConditionReference);
             addToBundle(bundle, diagnoseFM);
           }
 
@@ -154,7 +155,7 @@ public class ObdsToFhirBundleMapper extends ObdsToFhirMapper {
           if (verlauf.getMengeFM() != null && verlauf.getMengeFM().getFernmetastase() != null) {
             var verlaufFM =
                 fernmetastasenMapper.map(
-                    meldung.getVerlauf(), patientReference, primaryConditionReference);
+                    verlauf, meldung.getMeldungID(), patientReference, primaryConditionReference);
             addToBundle(bundle, verlaufFM);
           }
 
@@ -260,6 +261,7 @@ public class ObdsToFhirBundleMapper extends ObdsToFhirMapper {
           }
         }
 
+        // Pathologie
         if (meldung.getPathologie() != null) {
           var pathologie = meldung.getPathologie();
           var specimenReference = new Reference();
@@ -288,6 +290,17 @@ public class ObdsToFhirBundleMapper extends ObdsToFhirMapper {
                 lymphknotenuntersuchungMapper.map(
                     histologie, patientReference, primaryConditionReference, specimenReference);
             addToBundle(bundle, lymphknotenuntersuchungen);
+          }
+
+          if (pathologie.getMengeFM() != null
+              && pathologie.getMengeFM().getFernmetastase() != null) {
+            var pathologieFM =
+                fernmetastasenMapper.map(
+                    pathologie,
+                    meldung.getMeldungID(),
+                    patientReference,
+                    primaryConditionReference);
+            addToBundle(bundle, pathologieFM);
           }
 
           // TODO: Tumorkonferenz reference needed here

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/FernmetastasenMapperTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/mii/FernmetastasenMapperTest.java
@@ -41,11 +41,15 @@ class FernmetastasenMapperTest extends MapperTest {
 
     for (var meldung : obdsPatient.getMengeMeldung().getMeldung()) {
       if (meldung.getDiagnose() != null && meldung.getDiagnose().getMengeFM() != null) {
-        list.addAll(sut.map(meldung.getDiagnose(), subject, diagnose));
+        list.addAll(sut.map(meldung.getDiagnose(), meldung.getMeldungID(), subject, diagnose));
       }
 
       if (meldung.getVerlauf() != null && meldung.getVerlauf().getMengeFM() != null) {
-        list.addAll(sut.map(meldung.getVerlauf(), subject, diagnose));
+        list.addAll(sut.map(meldung.getVerlauf(), meldung.getMeldungID(), subject, diagnose));
+      }
+
+      if (meldung.getPathologie() != null && meldung.getPathologie().getMengeFM() != null) {
+        list.addAll(sut.map(meldung.getPathologie(), meldung.getMeldungID(), subject, diagnose));
       }
     }
 

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/FernmetastasenMapperTest.map_withGivenObds_shouldCreateValidObservation.Testpatient_1.xml.index_0.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/FernmetastasenMapperTest.map_withGivenObds_shouldCreateValidObservation.Testpatient_1.xml.index_0.approved.fhir.json
@@ -1,12 +1,12 @@
 {
   "resourceType": "Observation",
-  "id": "15b43de338af8fcbcf8ed4326337eb4395370406ec0dbf80bc06cb394556e2fc",
+  "id": "ce9ac4ea209e8287513499093af316c9a589459a575f7fa6c4499530ceaed1da",
   "meta": {
     "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-fernmetastasen" ]
   },
   "identifier": [ {
     "system": "https://bzkf.github.io/obds-to-fhir/identifiers/fernmetastasen-id",
-    "value": "Diagnose_0"
+    "value": "10_1_DI_1-Diagnose-0"
   } ],
   "status": "final",
   "code": {

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/FernmetastasenMapperTest.map_withGivenObds_shouldCreateValidObservation.Testpatient_1.xml.index_1.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/FernmetastasenMapperTest.map_withGivenObds_shouldCreateValidObservation.Testpatient_1.xml.index_1.approved.fhir.json
@@ -1,12 +1,12 @@
 {
   "resourceType": "Observation",
-  "id": "4d91f4e5eca532dc6a54892fd1fe68f48725d12fc37dba2d13217c4483a12605",
+  "id": "ddbc380f1daef8dfac48e0cfea3a6c594bf1354ffdbb7a71eae13ab27e9b39ca",
   "meta": {
     "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-fernmetastasen" ]
   },
   "identifier": [ {
     "system": "https://bzkf.github.io/obds-to-fhir/identifiers/fernmetastasen-id",
-    "value": "Verlauf_0"
+    "value": "10_1_VE-1-Verlauf-0"
   } ],
   "status": "final",
   "code": {

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest.map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.index_0.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest.map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.index_0.approved.fhir.json
@@ -139,16 +139,16 @@
       "url": "Observation/6ff37297dfe99bf538549b388e8a9dad85756899519ef6e8e1775da5273bac8d"
     }
   }, {
-    "fullUrl": "Observation/15b43de338af8fcbcf8ed4326337eb4395370406ec0dbf80bc06cb394556e2fc",
+    "fullUrl": "Observation/ce9ac4ea209e8287513499093af316c9a589459a575f7fa6c4499530ceaed1da",
     "resource": {
       "resourceType": "Observation",
-      "id": "15b43de338af8fcbcf8ed4326337eb4395370406ec0dbf80bc06cb394556e2fc",
+      "id": "ce9ac4ea209e8287513499093af316c9a589459a575f7fa6c4499530ceaed1da",
       "meta": {
         "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-fernmetastasen" ]
       },
       "identifier": [ {
         "system": "https://bzkf.github.io/obds-to-fhir/identifiers/fernmetastasen-id",
-        "value": "Diagnose_0"
+        "value": "10_1_DI_1-Diagnose-0"
       } ],
       "status": "final",
       "code": {
@@ -173,7 +173,7 @@
     },
     "request": {
       "method": "PUT",
-      "url": "Observation/15b43de338af8fcbcf8ed4326337eb4395370406ec0dbf80bc06cb394556e2fc"
+      "url": "Observation/ce9ac4ea209e8287513499093af316c9a589459a575f7fa6c4499530ceaed1da"
     }
   }, {
     "fullUrl": "Specimen/fd0a202eb1bf417fe7e7e5b64f4ce312dad44cfd402d919c8d8861031e54b2b9",
@@ -1116,16 +1116,16 @@
       "url": "MedicationStatement/050a031e5a9043c28c565c6b60550c3d34cd059bc2f24c195cdb807f099cd978"
     }
   }, {
-    "fullUrl": "Observation/4d91f4e5eca532dc6a54892fd1fe68f48725d12fc37dba2d13217c4483a12605",
+    "fullUrl": "Observation/ddbc380f1daef8dfac48e0cfea3a6c594bf1354ffdbb7a71eae13ab27e9b39ca",
     "resource": {
       "resourceType": "Observation",
-      "id": "4d91f4e5eca532dc6a54892fd1fe68f48725d12fc37dba2d13217c4483a12605",
+      "id": "ddbc380f1daef8dfac48e0cfea3a6c594bf1354ffdbb7a71eae13ab27e9b39ca",
       "meta": {
         "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-fernmetastasen" ]
       },
       "identifier": [ {
         "system": "https://bzkf.github.io/obds-to-fhir/identifiers/fernmetastasen-id",
-        "value": "Verlauf_0"
+        "value": "10_1_VE-1-Verlauf-0"
       } ],
       "status": "final",
       "code": {
@@ -1150,7 +1150,7 @@
     },
     "request": {
       "method": "PUT",
-      "url": "Observation/4d91f4e5eca532dc6a54892fd1fe68f48725d12fc37dba2d13217c4483a12605"
+      "url": "Observation/ddbc380f1daef8dfac48e0cfea3a6c594bf1354ffdbb7a71eae13ab27e9b39ca"
     }
   }, {
     "fullUrl": "Specimen/ad4b122c2df5025505010afee92111e127e89d717e074e5b871d492999909a20",

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest.map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Mamma.xml.index_0.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest.map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Mamma.xml.index_0.approved.fhir.json
@@ -83,16 +83,16 @@
       "url": "Observation/f5cb9006f7ca2b67e940a5a95725a2fc6b1e1687be203f7d317802e45e377857"
     }
   }, {
-    "fullUrl": "Observation/4d91f4e5eca532dc6a54892fd1fe68f48725d12fc37dba2d13217c4483a12605",
+    "fullUrl": "Observation/7d9afbd70680a9fd458f4d21cb4be15181aacc3303ffdc1c34e6dd499ad94c30",
     "resource": {
       "resourceType": "Observation",
-      "id": "4d91f4e5eca532dc6a54892fd1fe68f48725d12fc37dba2d13217c4483a12605",
+      "id": "7d9afbd70680a9fd458f4d21cb4be15181aacc3303ffdc1c34e6dd499ad94c30",
       "meta": {
         "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-fernmetastasen" ]
       },
       "identifier": [ {
         "system": "https://bzkf.github.io/obds-to-fhir/identifiers/fernmetastasen-id",
-        "value": "Verlauf_0"
+        "value": "VER_60102-Verlauf-0"
       } ],
       "status": "final",
       "code": {
@@ -117,19 +117,19 @@
     },
     "request": {
       "method": "PUT",
-      "url": "Observation/4d91f4e5eca532dc6a54892fd1fe68f48725d12fc37dba2d13217c4483a12605"
+      "url": "Observation/7d9afbd70680a9fd458f4d21cb4be15181aacc3303ffdc1c34e6dd499ad94c30"
     }
   }, {
-    "fullUrl": "Observation/3ce6529ef47209775e80ed550d4867f7ebbb2134d55ae9bdc9b343edb58b9b70",
+    "fullUrl": "Observation/ac06b804e9c8f79d11988bd00ef0c8d229a04b880a8b3a3237a7ef9e3ed60528",
     "resource": {
       "resourceType": "Observation",
-      "id": "3ce6529ef47209775e80ed550d4867f7ebbb2134d55ae9bdc9b343edb58b9b70",
+      "id": "ac06b804e9c8f79d11988bd00ef0c8d229a04b880a8b3a3237a7ef9e3ed60528",
       "meta": {
         "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-fernmetastasen" ]
       },
       "identifier": [ {
         "system": "https://bzkf.github.io/obds-to-fhir/identifiers/fernmetastasen-id",
-        "value": "Verlauf_1"
+        "value": "VER_60102-Verlauf-1"
       } ],
       "status": "final",
       "code": {
@@ -154,7 +154,7 @@
     },
     "request": {
       "method": "PUT",
-      "url": "Observation/3ce6529ef47209775e80ed550d4867f7ebbb2134d55ae9bdc9b343edb58b9b70"
+      "url": "Observation/ac06b804e9c8f79d11988bd00ef0c8d229a04b880a8b3a3237a7ef9e3ed60528"
     }
   }, {
     "fullUrl": "Specimen/1d79688586bf4aab850a2f43b7b573f1f2c381a288a0996809df83bc94b6b6b3",

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest.map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Patho.xml.index_0.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest.map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Patho.xml.index_0.approved.fhir.json
@@ -351,6 +351,43 @@
       "url": "Observation/db8a746bb6639e08043acf64d6d6a98296c714100692ef06b6d4536c1199912e"
     }
   }, {
+    "fullUrl": "Observation/7df77964205346253bbdb46fe59d65a1ba53c8d67248d60995a97143b00fdffb",
+    "resource": {
+      "resourceType": "Observation",
+      "id": "7df77964205346253bbdb46fe59d65a1ba53c8d67248d60995a97143b00fdffb",
+      "meta": {
+        "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-fernmetastasen" ]
+      },
+      "identifier": [ {
+        "system": "https://bzkf.github.io/obds-to-fhir/identifiers/fernmetastasen-id",
+        "value": "PAT_70101-Pathologie-0"
+      } ],
+      "status": "final",
+      "code": {
+        "coding": [ {
+          "system": "http://snomed.info/sct",
+          "code": "385421009"
+        } ]
+      },
+      "subject": {
+        "reference": "Patient/17fd07c897c1b71242be625380c0f570dd1262c3e8e6716c09819705494d65b5"
+      },
+      "focus": [ {
+        "reference": "Condition/5d2cdde0faa8926327a75daff8ae2c78751648e0c50c975a5583e637c351850c"
+      } ],
+      "effectiveDateTime": "2022-08-05",
+      "valueCodeableConcept": {
+        "coding": [ {
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-fernmetastasen",
+          "code": "PUL"
+        } ]
+      }
+    },
+    "request": {
+      "method": "PUT",
+      "url": "Observation/7df77964205346253bbdb46fe59d65a1ba53c8d67248d60995a97143b00fdffb"
+    }
+  }, {
     "fullUrl": "DiagnosticReport/dbd58c18b6360f5db3b0e6595a976abb94a71c176689e2dc30a156fde98fa20b",
     "resource": {
       "resourceType": "DiagnosticReport",


### PR DESCRIPTION
Gerade #241 gemergt und dann gesehen: Aus PathologieTyp können auch Fernmetastasen kommen, ist hiermit ergänzt.
Auch den identifier um MeldungID ergänzt, sonst könnte es, falls es mehrere Verlaufs oder Patho Meldungen zu FM gibt, zu kollisionen kommen. Das "source" wäre dann vermutlich redundant - ggf trotzdem interessant zum debuggen.