### PR TITLE
ci: only load the test image on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
           path: /tmp
 
       - name: Load image
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           docker load --input /tmp/image.tar
           docker image ls


### PR DESCRIPTION
on pushes to master/beta it's already tagged and pushed to the registry