### PR TITLE
fix: map SYST Protokoll to Procedure.code.text

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -115,6 +115,28 @@ it is not.
 Prefer [constructor-based dependency injection](https://docs.spring.io/spring-framework/reference/core/beans/dependencies/factory-collaborators.html#beans-constructor-injection)
 over field or setter injection.
 
+## Snapshot testing
+
+The project makes extensive use of snapshot testing to verify the created FHIR resources and avoid regressions.
+We use <https://github.com/approvals/ApprovalTests.Java> for this.
+
+### Approving changes automatically
+
+Usually, approving a changed snapshots requires manually renaming or moving the snapshot file from `.received.` to `.approved.`.
+If you are facing a lot of changed snapshots and are certain that your changes are valid, you can automatically approve them:
+
+```sh
+APPROVAL_TESTS_USE_REPORTER=AutoApproveReporter ./gradlew test
+```
+
+Source: <https://github.com/approvals/ApprovalTests.Java/issues/590>.
+
+You can also run this in a loop to approve indexed snapshots:
+
+```sh
+for i in {1..10}; do APPROVAL_TESTS_USE_REPORTER=AutoApproveReporter ./gradlew test; done
+```
+
 ## Releases
 
 The project aims for frequent releases. We achieve this using semantic-release, where

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/mii/SystemischeTherapieMedicationStatementMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/mii/SystemischeTherapieMedicationStatementMapper.java
@@ -56,8 +56,6 @@ public class SystemischeTherapieMedicationStatementMapper extends ObdsToFhirMapp
               new CodeableConcept().setText(substanz.getBezeichnung()));
         }
 
-        // TODO: can we be sure that this SYST-ID is globally unqiue across all SYSTs?
-        // if not we may instead need to construct the ID from the patient-id + others.
         var identifier =
             new Identifier()
                 .setSystem(

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.0.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.0.approved.fhir.json
@@ -1304,7 +1304,8 @@
         }, {
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-therapie-typ",
           "code": "IM"
-        } ]
+        } ],
+        "text": "Atezolizumab Immuntherapie"
       },
       "subject": {
         "reference": "Patient/a02e16474896f1d528cac71f2c9b4c45ac3c9028e3a53fb414a1f7882991ee07"

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_CLL.xml.0.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_CLL.xml.0.approved.fhir.json
@@ -249,7 +249,8 @@
         }, {
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-therapie-typ",
           "code": "CI"
-        } ]
+        } ],
+        "text": "FCR"
       },
       "subject": {
         "reference": "Patient/66eab990c3ab4a1dac96eecfa7189a4455b4a4e9d39b1813fa20e17b8cc564d2"

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Mamma.xml.0.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Mamma.xml.0.approved.fhir.json
@@ -2563,7 +2563,8 @@
         }, {
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-therapie-typ",
           "code": "CH"
-        } ]
+        } ],
+        "text": "Cisplatin"
       },
       "subject": {
         "reference": "Patient/9142ee3ff7990f826ada966f03da267e0fe662f73858158f5e868b772cd68730"
@@ -2653,7 +2654,8 @@
         }, {
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-therapie-typ",
           "code": "HO"
-        } ]
+        } ],
+        "text": "Anastrozol"
       },
       "subject": {
         "reference": "Patient/9142ee3ff7990f826ada966f03da267e0fe662f73858158f5e868b772cd68730"

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Prostata.xml.0.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Prostata.xml.0.approved.fhir.json
@@ -271,7 +271,8 @@
         }, {
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-therapie-typ",
           "code": "HO"
-        } ]
+        } ],
+        "text": "Hormontherapie Buserelin"
       },
       "subject": {
         "reference": "Patient/23283daf4d699cc4b3e9d01cd4ce1344cd94f9f9769dfd88da68b2b696332d48"

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Rektum.xml.0.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Rektum.xml.0.approved.fhir.json
@@ -1065,7 +1065,8 @@
         }, {
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-therapie-typ",
           "code": "CH"
-        } ]
+        } ],
+        "text": "FOLFOX-4"
       },
       "subject": {
         "reference": "Patient/4a8639bbad9d5774878e0d6a132ece2b65912449072a6888e2028987d5d479c4"

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testperson_CervixC53.xml.0.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testperson_CervixC53.xml.0.approved.fhir.json
@@ -202,7 +202,8 @@
         }, {
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-therapie-typ",
           "code": "CH"
-        } ]
+        } ],
+        "text": "Cisplatin/Etoposid"
       },
       "subject": {
         "reference": "Patient/5098a39800d97f3939da3ee42943b863a227d051c05789f223880279dc077203"
@@ -331,7 +332,8 @@
         }, {
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-therapie-typ",
           "code": "CH"
-        } ]
+        } ],
+        "text": "Carboplatin/Etoposid"
       },
       "subject": {
         "reference": "Patient/5098a39800d97f3939da3ee42943b863a227d051c05789f223880279dc077203"

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/SystemischeTherapieProcedureMapperTest.map_withGivenObds_shouldCreateValidProcedure.Testpatient_1.xml.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/mapper/mii/SystemischeTherapieProcedureMapperTest.map_withGivenObds_shouldCreateValidProcedure.Testpatient_1.xml.approved.fhir.json
@@ -43,7 +43,8 @@
     }, {
       "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-therapie-typ",
       "code": "IM"
-    } ]
+    } ],
+    "text": "Atezolizumab Immuntherapie"
   },
   "subject": {
     "reference": "Patient/any"


### PR DESCRIPTION
Sollte eigentlich laut https://simplifier.net/guide/mii-ig-modul-onkologie-2024-de/MIIIGModulOnkologie/TechnischeImplementierung/FHIR-Profile/Systemische-Therapie/Systemische-Therapie-MedicationStatement.page.md?version=current in MedicationStatement abgebildet werden, aber für den Fall, dass es kein ATC-codiertes Medikament ist, ist dann kein Platz mehr in medicationCodeableConcept.text

Closes #371 