### PR TITLE
feat: include Bestrahlung data as list of extensions - compliant with the DKTK profiles

### DIFF
--- a/src/main/java/org/miracum/streams/ume/obdstofhir/FhirProperties.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/FhirProperties.java
@@ -23,6 +23,7 @@ public class FhirProperties {
     private String sysTheraProto;
     private String dataAbsentReason;
     private String genderAmtlich;
+    private String stBestrahlung;
   }
 
   @Data
@@ -65,6 +66,9 @@ public class FhirProperties {
     private String gleasonScoreObservationId;
     private String psaObservationId;
     private String ucum;
+    private String stApplikationsArt;
+    private String stZielgebiet;
+    private String stStrahlenart;
   }
 
   @Data

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsProcedureMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsProcedureMapper.java
@@ -87,43 +87,10 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
     }
 
     if (meldung != null && meldung.getMenge_ST() != null && meldung.getMenge_ST().getST() != null) {
-      var radioTherapy = meldung.getMenge_ST().getST();
-
-      if (radioTherapy.getMenge_Bestrahlung() != null) {
-        var partialRadiations = radioTherapy.getMenge_Bestrahlung().getBestrahlung();
-        var distinctPartialRadiations = new HashSet<>(partialRadiations); // removes duplicates
-        var timeSpan = getTimeSpanFromPartialRadiations(partialRadiations);
-
-        if (distinctPartialRadiations.size() > 1) {
-          bundle =
-              addResourceAsEntryInBundle(
-                  bundle,
-                  createRadiotherapyProcedure(
-                      meldung,
-                      pid,
-                      senderId,
-                      softwareId,
-                      reportingReason,
-                      null,
-                      timeSpan,
-                      distinctPartialRadiations));
-        }
-
-        for (var radio : distinctPartialRadiations) {
-          bundle =
-              addResourceAsEntryInBundle(
-                  bundle,
-                  createRadiotherapyProcedure(
-                      meldung,
-                      pid,
-                      senderId,
-                      softwareId,
-                      reportingReason,
-                      radio,
-                      null,
-                      distinctPartialRadiations));
-        }
-      }
+      bundle =
+          addResourceAsEntryInBundle(
+              bundle,
+              createRadiotherapyProcedure(meldung, pid, senderId, softwareId, reportingReason));
     }
 
     bundle.setType(Bundle.BundleType.TRANSACTION);
@@ -133,6 +100,10 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
     } else {
       return bundle;
     }
+  }
+
+  public Procedure createRadioTherapyProcedure() {
+    return null;
   }
 
   public Procedure createOpProcedure(
@@ -304,75 +275,18 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
   // Create a ST Procedure as in
   // https://simplifier.net/oncology/strahlentherapie
   public Procedure createRadiotherapyProcedure(
-      Meldung meldung,
-      String pid,
-      String senderId,
-      String softwareId,
-      Meldeanlass meldeanlass,
-      Bestrahlung radio,
-      Tupel<Date, Date> timeSpan,
-      Set<Bestrahlung> distinctPartialRadiations) {
+      Meldung meldung, String pid, String senderId, String softwareId, Meldeanlass meldeanlass) {
 
     var radioTherapy = meldung.getMenge_ST().getST();
 
-    var partOfId = pid + "st-partOf-procedure" + radioTherapy.getST_ID();
+    var tumorId = meldung.getTumorzuordnung().getTumor_ID();
+
+    var id = pid + "-" + tumorId + "-" + radioTherapy.getST_ID();
 
     var stProcedure = new Procedure();
 
-    if (radio != null) {
-      var stBeginnDateString = radio.getST_Beginn_Datum();
-      var stEndDateString = radio.getST_Ende_Datum();
-
-      var id =
-          pid
-              + "st-procedure"
-              + radioTherapy.getST_ID()
-              + stBeginnDateString
-              + radio.getST_Zielgebiet()
-              + radio.getST_Seite_Zielgebiet()
-              + radio.getST_Applikationsart();
-
-      // Id
-      stProcedure.setId(this.getHash(ResourceType.Procedure, id));
-
-      // PartOf
-      if (distinctPartialRadiations.size() > 1) {
-        stProcedure.setPartOf(
-            List.of(
-                new Reference()
-                    .setReference(
-                        ResourceType.Procedure
-                            + "/"
-                            + this.getHash(ResourceType.Procedure, partOfId))));
-      }
-      // Performed
-      DateTimeType stBeginnDateType = convertObdsDateToDateTimeType(stBeginnDateString);
-      DateTimeType stEndDateType = convertObdsDateToDateTimeType(stEndDateString);
-
-      if (stBeginnDateType != null && stEndDateType != null) {
-        stProcedure.setPerformed(
-            new Period().setStartElement(stBeginnDateType).setEndElement(stEndDateType));
-      } else if (stBeginnDateType != null) {
-        stProcedure.setPerformed(new Period().setStartElement(stBeginnDateType));
-      }
-    } else {
-      // Id
-      stProcedure.setId(this.getHash(ResourceType.Procedure, partOfId));
-
-      // Performed
-      if (timeSpan != null) {
-        var minDate = timeSpan.getFirst();
-        var maxDate = timeSpan.getSecond();
-        if (minDate != null && maxDate != null) {
-          stProcedure.setPerformed(
-              new Period()
-                  .setStartElement(new DateTimeType(minDate))
-                  .setEndElement(new DateTimeType(maxDate)));
-        } else if (minDate != null) {
-          stProcedure.setPerformed(new Period().setStartElement(new DateTimeType(minDate)));
-        }
-      }
-    }
+    // Id
+    stProcedure.setId(this.getHash(ResourceType.Procedure, id));
 
     // Meta
     stProcedure.getMeta().setSource(generateProfileMetaSource(senderId, softwareId, appVersion));
@@ -408,6 +322,108 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
                         .setCode(systIntention)
                         .setSystem(fhirProperties.getSystems().getSystIntention())
                         .setDisplay(SystIntentionVsLookup.lookupDisplay(systIntention))));
+
+    // add the individual Bestrahlungen as a list of extensions
+    if (radioTherapy.getMenge_Bestrahlung() != null
+        && radioTherapy.getMenge_Bestrahlung().getBestrahlung() != null) {
+      var bestrahlungen = radioTherapy.getMenge_Bestrahlung().getBestrahlung();
+      var distinctPartialRadiations = new HashSet<>(bestrahlungen); // removes duplicates
+
+      if (bestrahlungen.size() > distinctPartialRadiations.size()) {
+        LOG.warn("Found duplicate Bestrahlung entries in ST: ST_ID={}", radioTherapy.getST_ID());
+      }
+
+      var timeSpan = getTimeSpanFromPartialRadiations(distinctPartialRadiations.stream().toList());
+
+      // Performed
+      if (timeSpan != null) {
+        var minDate = timeSpan.getFirst();
+        var maxDate = timeSpan.getSecond();
+        if (minDate != null && maxDate != null) {
+          stProcedure.setPerformed(
+              new Period()
+                  .setStartElement(new DateTimeType(minDate))
+                  .setEndElement(new DateTimeType(maxDate)));
+        } else if (minDate != null) {
+          stProcedure.setPerformed(new Period().setStartElement(new DateTimeType(minDate)));
+        }
+      } else {
+        LOG.warn(
+            "No usable start or end date found for Bestrahlung entries in ST: ST_ID={}",
+            radioTherapy.getST_ID());
+      }
+
+      for (var radio : distinctPartialRadiations) {
+        var bestrahlungExtension =
+            new Extension().setUrl(fhirProperties.getExtensions().getStBestrahlung());
+
+        // Performed
+        var stBeginnDateType = convertObdsDateToDateTimeType(radio.getST_Beginn_Datum());
+        var stEndDateType = convertObdsDateToDateTimeType(radio.getST_Ende_Datum());
+
+        var performed = new Period();
+
+        if (stBeginnDateType != null) {
+          performed.setStartElement(stBeginnDateType);
+        }
+
+        if (stEndDateType != null) {
+          performed.setEndElement(stEndDateType);
+        }
+
+        // this is not a valid DKTK extension
+        // only set it if atleast one date is available
+        if (stBeginnDateType != null || stEndDateType != null) {
+          bestrahlungExtension.addExtension(new Extension().setUrl("Zeitraum").setValue(performed));
+        }
+
+        if (radio.getST_Applikationsart() != null) {
+          var applikationsartCoding =
+              new Coding()
+                  .setSystem(fhirProperties.getSystems().getStApplikationsArt())
+                  .setCode(radio.getST_Applikationsart());
+          bestrahlungExtension.addExtension(
+              new Extension()
+                  .setUrl("Applikationsart")
+                  .setValue(new CodeableConcept().addCoding(applikationsartCoding)));
+        }
+
+        if (radio.getST_Zielgebiet() != null) {
+          var zielgebietCoding =
+              new Coding()
+                  .setSystem(fhirProperties.getSystems().getStZielgebiet())
+                  .setCode(radio.getST_Zielgebiet());
+          bestrahlungExtension.addExtension(
+              new Extension()
+                  .setUrl("Zielgebiet")
+                  .setValue(new CodeableConcept().addCoding(zielgebietCoding)));
+        }
+
+        if (radio.getST_Seite_Zielgebiet() != null) {
+          var seiteZielgebietCoding =
+              new Coding()
+                  .setSystem(fhirProperties.getSystems().getAdtSeitenlokalisation())
+                  .setCode(radio.getST_Seite_Zielgebiet());
+          bestrahlungExtension.addExtension(
+              new Extension()
+                  .setUrl("SeiteZielgebiet")
+                  .setValue(new CodeableConcept().addCoding(seiteZielgebietCoding)));
+        }
+
+        if (radio.getST_Strahlenart() != null) {
+          var strahlenartCoding =
+              new Coding()
+                  .setSystem(fhirProperties.getSystems().getStStrahlenart())
+                  .setCode(radio.getST_Strahlenart());
+          bestrahlungExtension.addExtension(
+              new Extension()
+                  .setUrl("Strahlenart")
+                  .setValue(new CodeableConcept().addCoding(strahlenartCoding)));
+        }
+
+        stProcedure.addExtension(bestrahlungExtension);
+      }
+    }
 
     // Status
     if (meldeanlass == Meldeanlass.BEHANDLUNGSENDE) {

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsProcedureMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsProcedureMapper.java
@@ -102,10 +102,6 @@ public class ObdsProcedureMapper extends ObdsToFhirMapper {
     }
   }
 
-  public Procedure createRadioTherapyProcedure() {
-    return null;
-  }
-
   public Procedure createOpProcedure(
       Meldung meldung,
       String pid,

--- a/src/main/java/org/miracum/streams/ume/obdstofhir/model/ADT_GEKID.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/model/ADT_GEKID.java
@@ -425,6 +425,7 @@ public class ADT_GEKID implements Serializable {
                   @JsonProperty @EqualsAndHashCode.Include private String ST_Zielgebiet;
                   @JsonProperty @EqualsAndHashCode.Include private String ST_Seite_Zielgebiet;
                   @JsonProperty @EqualsAndHashCode.Include private String ST_Applikationsart;
+                  @JsonProperty @EqualsAndHashCode.Include private String ST_Strahlenart;
                 }
               }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,7 @@ fhir:
     stellungOP: "http://dktk.dkfz.de/fhir/StructureDefinition/onco-core-Extension-StellungZurOp"
     systIntention: "http://dktk.dkfz.de/fhir/StructureDefinition/onco-core-Extension-SYSTIntention"
     sysTheraProto: "http://dktk.dkfz.de/fhir/StructureDefinition/onco-core-Extension-SystemischeTherapieProtokoll"
+    stBestrahlung: "http://dktk.dkfz.de/fhir/StructureDefinition/onco-core-Extension-Bestrahlung"
     dataAbsentReason: "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
     genderAmtlich: "http://fhir.de/StructureDefinition/gender-amtlich-de"
   systems:
@@ -45,6 +46,9 @@ fhir:
     gesamtBeurtResidualCS: "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/GesamtbeurteilungResidualstatusCS"
     systIntention: "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/SYSTIntentionCS"
     systStellungOP: "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/SYSTStellungOPCS"
+    stApplikationsArt: "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/ApplikationsartCS"
+    stZielgebiet: "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/ZielgebietCS"
+    stStrahlenart: "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/StrahlenartCS"
     ctcaeGrading: "http://hl7.org/fhir/us/ctcae/CodeSystem/ctcae-grade-code-system"
     sideEffectTypeOid: "urn:oid:1.2.276.0.76.3.1.131.1.5.20"
     opComplication: "urn:oid:1.2.276.0.76.3.1.131.1.5.122"

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/processor/ObdsProcedureProcessorTest.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/processor/ObdsProcedureProcessorTest.java
@@ -60,9 +60,9 @@ class ObdsProcedureProcessorTest extends ObdsProcessorTest {
             "Nein"),
         Arguments.of(
             List.of(new Tupel<>("007_Pat2_Tumor1_Behandlungsende_ST.xml", 1)),
-            3,
+            1,
             0,
-            3,
+            1,
             0,
             "COMPLETED",
             "",

--- a/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/processor/ObdsProcedureProcessorTest.mapProcedure_withGivenAdtXml.007_P.approved.fhir.json
+++ b/src/test/java/snapshots/org/miracum/streams/ume/obdstofhir/processor/ObdsProcedureProcessorTest.mapProcedure_withGivenAdtXml.007_P.approved.fhir.json
@@ -2,10 +2,10 @@
   "resourceType": "Bundle",
   "type": "transaction",
   "entry": [ {
-    "fullUrl": "Procedure/4a4b6d61ed9f40f3d3c809e2ca3844a234684e87fa711262acf14ced88533567",
+    "fullUrl": "Procedure/4ff2d57d7b7061fab401adf3d7e4e7fbf29b5c5eb62ba1196a63df6de098c389",
     "resource": {
       "resourceType": "Procedure",
-      "id": "4a4b6d61ed9f40f3d3c809e2ca3844a234684e87fa711262acf14ced88533567",
+      "id": "4ff2d57d7b7061fab401adf3d7e4e7fbf29b5c5eb62ba1196a63df6de098c389",
       "meta": {
         "source": "999999.ONKOSTAR:obds-to-fhir:0.0.0-test",
         "profile": [ "http://dktk.dkfz.de/fhir/StructureDefinition/onco-core-Procedure-Strahlentherapie" ]
@@ -28,6 +28,49 @@
             "display": "palliativ"
           } ]
         }
+      }, {
+        "url": "http://dktk.dkfz.de/fhir/StructureDefinition/onco-core-Extension-Bestrahlung",
+        "extension": [ {
+          "url": "Zeitraum",
+          "valuePeriod": {
+            "end": "2021-12-02"
+          }
+        }, {
+          "url": "Zielgebiet",
+          "valueCodeableConcept": {
+            "coding": [ {
+              "system": "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/ZielgebietCS",
+              "code": "1.2"
+            } ]
+          }
+        }, {
+          "url": "SeiteZielgebiet",
+          "valueCodeableConcept": {
+            "coding": [ {
+              "system": "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/SeitenlokalisationCS",
+              "code": "R"
+            } ]
+          }
+        } ]
+      }, {
+        "url": "http://dktk.dkfz.de/fhir/StructureDefinition/onco-core-Extension-Bestrahlung",
+        "extension": [ {
+          "url": "Zielgebiet",
+          "valueCodeableConcept": {
+            "coding": [ {
+              "system": "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/ZielgebietCS",
+              "code": "5.4.-"
+            } ]
+          }
+        }, {
+          "url": "SeiteZielgebiet",
+          "valueCodeableConcept": {
+            "coding": [ {
+              "system": "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/SeitenlokalisationCS",
+              "code": "T"
+            } ]
+          }
+        } ]
       } ],
       "status": "completed",
       "category": {
@@ -63,141 +106,7 @@
     },
     "request": {
       "method": "PUT",
-      "url": "Procedure/4a4b6d61ed9f40f3d3c809e2ca3844a234684e87fa711262acf14ced88533567"
-    }
-  }, {
-    "fullUrl": "Procedure/2fc2717fbb9ec3e8d54ec4ffe4817efc8de93dfcbd34db55f20ca53986227dc5",
-    "resource": {
-      "resourceType": "Procedure",
-      "id": "2fc2717fbb9ec3e8d54ec4ffe4817efc8de93dfcbd34db55f20ca53986227dc5",
-      "meta": {
-        "source": "999999.ONKOSTAR:obds-to-fhir:0.0.0-test",
-        "profile": [ "http://dktk.dkfz.de/fhir/StructureDefinition/onco-core-Procedure-Strahlentherapie" ]
-      },
-      "extension": [ {
-        "url": "http://dktk.dkfz.de/fhir/StructureDefinition/onco-core-Extension-StellungZurOp",
-        "valueCodeableConcept": {
-          "coding": [ {
-            "system": "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/SYSTStellungOPCS",
-            "code": "N",
-            "display": "neoadjuvant"
-          } ]
-        }
-      }, {
-        "url": "http://dktk.dkfz.de/fhir/StructureDefinition/onco-core-Extension-SYSTIntention",
-        "valueCodeableConcept": {
-          "coding": [ {
-            "system": "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/SYSTIntentionCS",
-            "code": "P",
-            "display": "palliativ"
-          } ]
-        }
-      } ],
-      "partOf": [ {
-        "reference": "Procedure/4a4b6d61ed9f40f3d3c809e2ca3844a234684e87fa711262acf14ced88533567"
-      } ],
-      "status": "completed",
-      "category": {
-        "coding": [ {
-          "system": "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/SYSTTherapieartCS",
-          "code": "ST",
-          "display": "Strahlentherapie"
-        } ]
-      },
-      "subject": {
-        "reference": "Patient/d9d6b458471f3ff3d65af6021a10d1112718a032eec4b843606616c5faa29937",
-        "identifier": {
-          "type": {
-            "coding": [ {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-              "code": "MR"
-            } ]
-          },
-          "system": "https://fhir.diz.uk-erlangen.de/identifiers/patient-id",
-          "value": "1055555888"
-        }
-      },
-      "reasonReference": [ {
-        "reference": "Condition/7f1aeff536cbf279167b567fbd01427d0ac271d1a3d3b13dedf8561587a45fff"
-      } ],
-      "complication": [ {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/us/ctcae/CodeSystem/ctcae-grade-code-system",
-          "code": "4",
-          "display": "lebensbedrohlich"
-        } ]
-      } ]
-    },
-    "request": {
-      "method": "PUT",
-      "url": "Procedure/2fc2717fbb9ec3e8d54ec4ffe4817efc8de93dfcbd34db55f20ca53986227dc5"
-    }
-  }, {
-    "fullUrl": "Procedure/5cc816ec84696364d264533059889822137ee92a943ad945eab1dbac304475ce",
-    "resource": {
-      "resourceType": "Procedure",
-      "id": "5cc816ec84696364d264533059889822137ee92a943ad945eab1dbac304475ce",
-      "meta": {
-        "source": "999999.ONKOSTAR:obds-to-fhir:0.0.0-test",
-        "profile": [ "http://dktk.dkfz.de/fhir/StructureDefinition/onco-core-Procedure-Strahlentherapie" ]
-      },
-      "extension": [ {
-        "url": "http://dktk.dkfz.de/fhir/StructureDefinition/onco-core-Extension-StellungZurOp",
-        "valueCodeableConcept": {
-          "coding": [ {
-            "system": "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/SYSTStellungOPCS",
-            "code": "N",
-            "display": "neoadjuvant"
-          } ]
-        }
-      }, {
-        "url": "http://dktk.dkfz.de/fhir/StructureDefinition/onco-core-Extension-SYSTIntention",
-        "valueCodeableConcept": {
-          "coding": [ {
-            "system": "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/SYSTIntentionCS",
-            "code": "P",
-            "display": "palliativ"
-          } ]
-        }
-      } ],
-      "partOf": [ {
-        "reference": "Procedure/4a4b6d61ed9f40f3d3c809e2ca3844a234684e87fa711262acf14ced88533567"
-      } ],
-      "status": "completed",
-      "category": {
-        "coding": [ {
-          "system": "http://dktk.dkfz.de/fhir/onco/core/CodeSystem/SYSTTherapieartCS",
-          "code": "ST",
-          "display": "Strahlentherapie"
-        } ]
-      },
-      "subject": {
-        "reference": "Patient/d9d6b458471f3ff3d65af6021a10d1112718a032eec4b843606616c5faa29937",
-        "identifier": {
-          "type": {
-            "coding": [ {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-              "code": "MR"
-            } ]
-          },
-          "system": "https://fhir.diz.uk-erlangen.de/identifiers/patient-id",
-          "value": "1055555888"
-        }
-      },
-      "reasonReference": [ {
-        "reference": "Condition/7f1aeff536cbf279167b567fbd01427d0ac271d1a3d3b13dedf8561587a45fff"
-      } ],
-      "complication": [ {
-        "coding": [ {
-          "system": "http://hl7.org/fhir/us/ctcae/CodeSystem/ctcae-grade-code-system",
-          "code": "4",
-          "display": "lebensbedrohlich"
-        } ]
-      } ]
-    },
-    "request": {
-      "method": "PUT",
-      "url": "Procedure/5cc816ec84696364d264533059889822137ee92a943ad945eab1dbac304475ce"
+      "url": "Procedure/4ff2d57d7b7061fab401adf3d7e4e7fbf29b5c5eb62ba1196a63df6de098c389"
     }
   } ]
 }


### PR DESCRIPTION
statt 1 Procedure pro Bestrahlung + Klammer-Procedure wird jetzt nur noch 1 Procedure mit der Liste der Bestrahlungen als Extensions angelegt. Die extension "Zeitraum" ist selbst eingeführt um die pro-Bestrahlung Datumsangaben darstellen zu können.