### PR TITLE
fix: if the date precision is completely estimated, don't set the value in the resource

### DIFF
--- a/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapper.java
+++ b/src/main/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapper.java
@@ -124,7 +124,7 @@ public abstract class ObdsToFhirMapper {
       }
       return resultBuilder.toString();
     } else {
-      log.warn("Identifier to convert does not match pattern: {}", matcher.pattern().toString());
+      log.warn("Identifier to convert does not match pattern: {}", matcher.pattern());
       return id;
     }
   }
@@ -331,12 +331,12 @@ public abstract class ObdsToFhirMapper {
         break;
       // vollständig geschätzt (genaue Angabe zum Jahr nicht möglich)
       case V:
-        date.setPrecision(TemporalPrecisionEnum.YEAR);
         log.warn(
-            "Date precision is completely estimated. Likely not a correct value. "
-                + "Defaulting to most granular 'year' precision.");
-        break;
+            "Input date precision is completely estimated. "
+                + "Not setting a date value in FHIR resource.");
+        return Optional.empty();
     }
+
     return Optional.of(date);
   }
 

--- a/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapperTests.java
+++ b/src/test/java/org/miracum/streams/ume/obdstofhir/mapper/ObdsToFhirMapperTests.java
@@ -222,6 +222,11 @@ class ObdsToFhirMapperTests {
 
     var actual = ObdsToFhirMapper.convertObdsDatumToDateType(datum);
 
+    if (datum.getDatumsgenauigkeit() == DatumsgenauigkeitTagOderMonatOderJahrOderNichtGenau.V) {
+      assertThat(actual).isEmpty();
+      return;
+    }
+
     assertThat(actual).isPresent();
     assertThat(actual.get().asStringValue()).isEqualTo(expected);
   }


### PR DESCRIPTION
Closes #467 