### PR TITLE
fix: increase default kafka template producer max.request.size

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -161,6 +161,8 @@ spring:
     producer:
       compression-type: gzip
       value-serializer: org.miracum.kafka.serializers.KafkaFhirSerializer
+      properties:
+        max.request.size: ${MAX_REQUEST_SIZE:20971520}
 
 logging:
   pattern:


### PR DESCRIPTION
The KafkaTemplate used when writing messages mapped from the filesystem to Kafka uses different config options than the streams processor

## Describe your changes

<!-- It's OK to be brief. Or skip this entirely if the changes are obvious. -->

## Issue ticket number and link

<!-- Optional -->

## Checklist before requesting a review

<!-- It's OK not to update the documentation or create new tests if deemed unnecessary -->

- [x] The commit message follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
