### PR TITLE
fix: change some fields from int to string

### DIFF
--- a/src/main/java/io/github/bzkf/obdstofhir/model/OnkoPatient.java
+++ b/src/main/java/io/github/bzkf/obdstofhir/model/OnkoPatient.java
@@ -19,7 +19,7 @@ public class OnkoPatient implements Serializable {
 
   @EqualsAndHashCode.Include
   @JsonProperty("ID")
-  Integer patid;
+  String patid;
 
   @JsonProperty("LETZTE_INFORMATION")
   LocalDate letzteInformation;
@@ -40,7 +40,7 @@ public class OnkoPatient implements Serializable {
   Integer zuLoeschen;
 
   @JsonProperty("PATIENTEN_IDS_VORHER")
-  Integer patientenIdsVorher;
+  String patientenIdsVorher;
 
   @JsonProperty("BEARBEITET_AM")
   LocalDateTime bearbeitetAm;


### PR DESCRIPTION
Changed patid and patientenIdsVorher fields from Integer to String. Due to overflow errors.

For the patid we could also do `BigDecimal`