### PR TITLE
fix: missing reference.identifier

### DIFF
--- a/mappings/src/main/java/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapper.java
+++ b/mappings/src/main/java/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapper.java
@@ -83,7 +83,7 @@ public class ObdsToFhirBundleMapper extends ObdsToFhirMapper {
   @Value("${fhir.mappings.meta.source}")
   private String metaSource;
 
-  @Value("${fhir.mappings.patient-id-regex:^(.*)$}")
+  @Value("${fhir.mappings.patient-id-regex}")
   private String patientIdRegex;
 
   private final Function<OBDS.MengePatient.Patient, Optional<Reference>> patientReferenceGenerator;

--- a/mappings/src/main/java/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapper.java
+++ b/mappings/src/main/java/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapper.java
@@ -221,7 +221,12 @@ public class ObdsToFhirBundleMapper extends ObdsToFhirMapper {
             "Unable to generate patient reference so using reference "
                 + "to patient to be created.");
         // this uses the default mechanism of referencing the created patient resource
-        patientReferenceOptional = Optional.of(createReferenceFromResource(patient));
+        var reference = createReferenceFromResource(patient);
+        // be sure to add the Reference.identifier as e.g. the TodMapper depends on it.
+        // XXX: this smells like a responsibility leak for reference generation spread
+        // across here and the patientReferenceGenerator.
+        reference.setIdentifier(patient.getIdentifierFirstRep());
+        patientReferenceOptional = Optional.of(reference);
       }
 
       var patientReference = patientReferenceOptional.get();


### PR DESCRIPTION
if the patient reference is generated within the ObdsToFhirBundleMapper, only the logical reference was created.