### PR TITLE
fix: set Condition.code.text from Primaertumor_Diagnosetext

### DIFF
--- a/mappings/src/main/java/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapper.java
+++ b/mappings/src/main/java/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapper.java
@@ -20,6 +20,7 @@ import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 public class ConditionMapper extends ObdsToFhirMapper {
@@ -116,7 +117,12 @@ public class ConditionMapper extends ObdsToFhirMapper {
     var icd10Version = tumorzuordnung.getPrimaertumorICD().getVersion();
     icd.setVersionElement(extractIcdVersionYear(icd10Version, "Primaertumor_ICD_Version", LOG));
 
-    condition.setCode(new CodeableConcept(icd));
+    var code = new CodeableConcept(icd);
+    if (meldung.getDiagnose() != null
+        && StringUtils.hasText(meldung.getDiagnose().getPrimaertumorDiagnosetext())) {
+      code.setText(meldung.getDiagnose().getPrimaertumorDiagnosetext());
+    }
+    condition.setCode(code);
 
     if (meldung.getDiagnose() != null && meldung.getDiagnose().getHistologie() != null) {
       var distinctMorphologyCodes =

--- a/mappings/src/test/java/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.java
+++ b/mappings/src/test/java/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.java
@@ -55,4 +55,30 @@ class ConditionMapperTest extends MapperTest {
 
     verify(condition, sourceFile);
   }
+
+  @ParameterizedTest
+  @CsvSource({"Testpatient_Diagnose.xml,Mamma-Ca", "Testpatient_leer.xml,"})
+  void map_withGivenObds_shouldSetCodeTextFromDiagnosetext(
+      String sourceFile, String expectedCodeText) throws IOException {
+    final var resource = this.getClass().getClassLoader().getResource("obds3/" + sourceFile);
+    assertThat(resource).isNotNull();
+
+    final var obds = xmlMapper().readValue(resource.openStream(), OBDS.class);
+
+    var obdsPatient = obds.getMengePatient().getPatient().getFirst();
+    var conMeldung =
+        obdsPatient.getMengeMeldung().getMeldung().stream()
+            .filter(m -> m.getDiagnose() != null)
+            .findFirst()
+            .get();
+
+    final var condition =
+        sut.map(
+            conMeldung,
+            new Reference("Patient/1"),
+            obds.getMeldedatum(),
+            obdsPatient.getPatientID());
+
+    assertThat(condition.getCode().getText()).isEqualTo(expectedCodeText);
+  }
 }

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.Testpatient_1.xml.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.Testpatient_1.xml.approved.fhir.json
@@ -37,7 +37,8 @@
       "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
       "version": "2020",
       "code": "C50.9"
-    } ]
+    } ],
+    "text": "Mamma-Ca"
   },
   "bodySite": [ {
     "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.Testpatient_2.xml.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.Testpatient_2.xml.approved.fhir.json
@@ -36,7 +36,8 @@
       "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
       "version": "2021",
       "code": "C61"
-    } ]
+    } ],
+    "text": "Prostata-Ca"
   },
   "bodySite": [ {
     "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.Testpatient_3.xml.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.Testpatient_3.xml.approved.fhir.json
@@ -37,7 +37,8 @@
       "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
       "version": "2017",
       "code": "C56"
-    } ]
+    } ],
+    "text": "Ovarial-Ca"
   },
   "bodySite": [ {
     "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.Testpatient_Diagnose.xml.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.Testpatient_Diagnose.xml.approved.fhir.json
@@ -37,7 +37,8 @@
       "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
       "version": "2020",
       "code": "C50.9"
-    } ]
+    } ],
+    "text": "Mamma-Ca"
   },
   "bodySite": [ {
     "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.Testpatient_Diagnose_ohne_Version.xml.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.Testpatient_Diagnose_ohne_Version.xml.approved.fhir.json
@@ -22,7 +22,8 @@
         } ]
       },
       "code": "C50.9"
-    } ]
+    } ],
+    "text": "Mamma-Ca"
   },
   "bodySite": [ {
     "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Priopatient_3.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Priopatient_3.xml.0.approved.fhir.json
@@ -78,7 +78,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2017",
           "code": "C56"
-        } ]
+        } ],
+        "text": "Ovarial-Ca"
       },
       "bodySite": [ {
         "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.0.approved.fhir.json
@@ -89,7 +89,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2020",
           "code": "C50.9"
-        } ]
+        } ],
+        "text": "Mamma-Ca"
       },
       "bodySite": [ {
         "coding": [ {
@@ -1442,7 +1443,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2020",
           "code": "C20"
-        } ]
+        } ],
+        "text": "Rektum-Ca"
       },
       "bodySite": [ {
         "coding": [ {
@@ -1841,7 +1843,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2020",
           "code": "C43.5"
-        } ]
+        } ],
+        "text": "Malignes Melanom"
       },
       "bodySite": [ {
         "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_2.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_2.xml.0.approved.fhir.json
@@ -77,7 +77,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2021",
           "code": "C61"
-        } ]
+        } ],
+        "text": "Prostata-Ca"
       },
       "bodySite": [ {
         "coding": [ {
@@ -930,7 +931,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2017",
           "code": "C91.1"
-        } ]
+        } ],
+        "text": "Chronisch lymphatische Leukämie"
       },
       "bodySite": [ {
         "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_3.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_3.xml.0.approved.fhir.json
@@ -78,7 +78,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2017",
           "code": "C56"
-        } ]
+        } ],
+        "text": "Ovarial-Ca"
       },
       "bodySite": [ {
         "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_CLL.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_CLL.xml.0.approved.fhir.json
@@ -78,7 +78,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2020",
           "code": "C91.1"
-        } ]
+        } ],
+        "text": "Chronisch lymphatische Leukämie"
       },
       "bodySite": [ {
         "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Mamma.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Mamma.xml.0.approved.fhir.json
@@ -84,7 +84,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2020",
           "code": "C50.4"
-        } ]
+        } ],
+        "text": "Mammakarzinom re."
       },
       "bodySite": [ {
         "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Prostata.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Prostata.xml.0.approved.fhir.json
@@ -83,7 +83,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2020",
           "code": "C61"
-        } ]
+        } ],
+        "text": "Prostatakarzinom"
       },
       "bodySite": [ {
         "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Rektum.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_Rektum.xml.0.approved.fhir.json
@@ -78,7 +78,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2020",
           "code": "C20"
-        } ]
+        } ],
+        "text": "Rektum-Ca"
       },
       "bodySite": [ {
         "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatientin_Cervix.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatientin_Cervix.xml.0.approved.fhir.json
@@ -83,7 +83,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2022",
           "code": "D06.9"
-        } ]
+        } ],
+        "text": "Cervix-Ca."
       },
       "bodySite": [ {
         "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testperson_CervixC53.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testperson_CervixC53.xml.0.approved.fhir.json
@@ -79,7 +79,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2018",
           "code": "C53.9"
-        } ]
+        } ],
+        "text": "Bösartige Neubildung: Cervix uteri, nicht näher bezeichnet"
       },
       "bodySite": [ {
         "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testperson_Cervixinsitu.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testperson_Cervixinsitu.xml.0.approved.fhir.json
@@ -84,7 +84,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2022",
           "code": "D06.9"
-        } ]
+        } ],
+        "text": "Cervix-Ca."
       },
       "bodySite": [ {
         "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperWithPatientIdRegexSetTest/map_withGivenObdsAndPatientIdRegex_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperWithPatientIdRegexSetTest/map_withGivenObdsAndPatientIdRegex_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.0.approved.fhir.json
@@ -89,7 +89,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2020",
           "code": "C50.9"
-        } ]
+        } ],
+        "text": "Mamma-Ca"
       },
       "bodySite": [ {
         "coding": [ {
@@ -1442,7 +1443,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2020",
           "code": "C20"
-        } ]
+        } ],
+        "text": "Rektum-Ca"
       },
       "bodySite": [ {
         "coding": [ {
@@ -1841,7 +1843,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2020",
           "code": "C43.5"
-        } ]
+        } ],
+        "text": "Malignes Melanom"
       },
       "bodySite": [ {
         "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperWithProvenanceEnabledTest/map_withGivenObdsAndEnabledProvenance_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperWithProvenanceEnabledTest/map_withGivenObdsAndEnabledProvenance_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.0.approved.fhir.json
@@ -89,7 +89,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2020",
           "code": "C50.9"
-        } ]
+        } ],
+        "text": "Mamma-Ca"
       },
       "bodySite": [ {
         "coding": [ {
@@ -1650,7 +1651,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2020",
           "code": "C20"
-        } ]
+        } ],
+        "text": "Rektum-Ca"
       },
       "bodySite": [ {
         "coding": [ {
@@ -2115,7 +2117,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2020",
           "code": "C43.5"
-        } ]
+        } ],
+        "text": "Malignes Melanom"
       },
       "bodySite": [ {
         "coding": [ {

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperWithProvenanceEnabledTest/map_withGivenObdsAndEnabledProvenance_shouldCreateBundleMatchingSnapshot.Testpatient_2.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperWithProvenanceEnabledTest/map_withGivenObdsAndEnabledProvenance_shouldCreateBundleMatchingSnapshot.Testpatient_2.xml.0.approved.fhir.json
@@ -77,7 +77,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2021",
           "code": "C61"
-        } ]
+        } ],
+        "text": "Prostata-Ca"
       },
       "bodySite": [ {
         "coding": [ {
@@ -1120,7 +1121,8 @@
           "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
           "version": "2017",
           "code": "C91.1"
-        } ]
+        } ],
+        "text": "Chronisch lymphatische Leukämie"
       },
       "bodySite": [ {
         "coding": [ {


### PR DESCRIPTION
`Diagnose/Primaertumor_Diagnosetext` was not read, so `Condition.code.text` stayed empty on
`mii-pr-onko-diagnose-primaertumor`, while `FruehereTumorerkrankungenMapper` sets the same element
for its own profile with a comment saying it always has to be set.

`ConditionMapper` now sets `Condition.code.text` from `Primaertumor_Diagnosetext` when it is present.

`./gradlew check` is green (19 + 132 tests, 0 failures): 19 approved snapshots gained the `code.text`
element and nothing else, and a new parameterized test covers one report with and one without the
free text.

Closes #730