### PR TITLE
fix: only assert ICD-10-GM when the oBDS version says GM

### DIFF
--- a/mappings/src/main/java/io/github/bzkf/obdstofhir/FhirProperties.java
+++ b/mappings/src/main/java/io/github/bzkf/obdstofhir/FhirProperties.java
@@ -122,6 +122,7 @@ public class FhirProperties {
     private String fMLokalisationCS;
     private String jnuCs;
     private String icd10gm;
+    private String icd10who;
     private String adtSeitenlokalisation;
     private String snomed;
     private String opIntention;

--- a/mappings/src/main/java/io/github/bzkf/obdstofhir/mapper/ObdsToFhirMapper.java
+++ b/mappings/src/main/java/io/github/bzkf/obdstofhir/mapper/ObdsToFhirMapper.java
@@ -24,9 +24,20 @@ public abstract class ObdsToFhirMapper {
       Slugify.builder().lowerCase(false).locale(Locale.GERMAN).build();
   private static final Logger log = LoggerFactory.getLogger(ObdsToFhirMapper.class);
 
-  /** Matches oBDS ICD-10 version strings, e.g. {@code "10 2023 GM"}, capturing the year. */
+  /**
+   * Matches oBDS ICD-10 version strings, e.g. {@code "10 2023 GM"}, capturing the year and the
+   * catalog.
+   */
   protected static final Pattern ICD_VERSION_PATTERN =
-      Pattern.compile("^(10 (?<versionYear>20\\d{2}) ((GM)|(WHO))|Sonstige)$");
+      Pattern.compile("^(10 (?<versionYear>20\\d{2}) (?<catalog>GM|WHO)|Sonstige)$");
+
+  /** The ICD-10 catalog named by an oBDS {@code *_ICD_Version}. */
+  public enum Icd10Catalog {
+    GM,
+    WHO,
+    /** {@code Sonstige}: the source states that neither GM nor WHO was used. */
+    OTHER
+  }
 
   protected ObdsToFhirMapper(final FhirProperties fhirProperties) {
     this.fhirProperties = fhirProperties;
@@ -60,6 +71,30 @@ public abstract class ObdsToFhirMapper {
     var versionElement = new StringType();
     versionElement.addExtension(DataAbsentReason.unknown());
     return versionElement;
+  }
+
+  /**
+   * Extracts the catalog from an oBDS ICD-10 version string (see {@link #ICD_VERSION_PATTERN}).
+   *
+   * @param icdVersion the raw ICD version string, e.g. from {@code *_ICD_Version}
+   * @return empty if the version is unset or doesn't match the expected format
+   */
+  protected static Optional<Icd10Catalog> extractIcdCatalog(String icdVersion) {
+    if (!StringUtils.hasText(icdVersion)) {
+      return Optional.empty();
+    }
+
+    var matcher = ICD_VERSION_PATTERN.matcher(icdVersion);
+    if (!matcher.matches()) {
+      return Optional.empty();
+    }
+
+    var catalog = matcher.group("catalog");
+    // the pattern matched without the catalog group, so the version is "Sonstige"
+    if (catalog == null) {
+      return Optional.of(Icd10Catalog.OTHER);
+    }
+    return Optional.of(Icd10Catalog.valueOf(catalog));
   }
 
   public static Optional<DateType> convertObdsDatumToDateType(

--- a/mappings/src/main/java/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapper.java
+++ b/mappings/src/main/java/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapper.java
@@ -109,19 +109,41 @@ public class ConditionMapper extends ObdsToFhirMapper {
 
     var tumorzuordnung = meldung.getTumorzuordnung();
 
-    var icd =
-        new Coding()
-            .setSystem(fhirProperties.getSystems().getIcd10gm())
-            .setCode(tumorzuordnung.getPrimaertumorICD().getCode());
+    var primaertumorIcd = tumorzuordnung.getPrimaertumorICD();
+    var icd10Version = primaertumorIcd.getVersion();
+    var icdVersionYear = extractIcdVersionYear(icd10Version, "Primaertumor_ICD_Version", LOG);
+    // an unset or unparsable version keeps the previous behaviour and is treated as GM
+    var catalog = extractIcdCatalog(icd10Version).orElse(Icd10Catalog.GM);
 
-    var icd10Version = tumorzuordnung.getPrimaertumorICD().getVersion();
-    icd.setVersionElement(extractIcdVersionYear(icd10Version, "Primaertumor_ICD_Version", LOG));
+    var icd = new Coding().setSystem(fhirProperties.getSystems().getIcd10gm());
+    if (catalog == Icd10Catalog.GM) {
+      icd.setCode(primaertumorIcd.getCode());
+      icd.setVersionElement(icdVersionYear);
+    } else {
+      // the source named another catalog, so neither the code nor the year apply to ICD-10-GM
+      icd.getCodeElement().addExtension(DataAbsentReason.notApplicable());
+      var absentVersion = new StringType();
+      absentVersion.addExtension(DataAbsentReason.notApplicable());
+      icd.setVersionElement(absentVersion);
+    }
 
     var code = new CodeableConcept(icd);
+    if (catalog == Icd10Catalog.WHO) {
+      code.addCoding(
+          new Coding()
+              .setSystem(fhirProperties.getSystems().getIcd10who())
+              .setCode(primaertumorIcd.getCode())
+              .setVersionElement(icdVersionYear));
+    }
+
     if (meldung.getDiagnose() != null
         && StringUtils.hasText(meldung.getDiagnose().getPrimaertumorDiagnosetext())) {
       code.setText(meldung.getDiagnose().getPrimaertumorDiagnosetext());
+    } else if (catalog == Icd10Catalog.OTHER) {
+      // no system can be asserted for "Sonstige", so keep the code as free text
+      code.setText(primaertumorIcd.getCode());
     }
+
     condition.setCode(code);
 
     if (meldung.getDiagnose() != null && meldung.getDiagnose().getHistologie() != null) {

--- a/mappings/src/main/resources/application-mappings.yml
+++ b/mappings/src/main/resources/application-mappings.yml
@@ -85,6 +85,7 @@ fhir:
     icdo3Morphologie: "http://terminology.hl7.org/CodeSystem/icd-o-3"
 
     icd10gm: "http://fhir.de/CodeSystem/bfarm/icd-10-gm"
+    icd10who: "http://hl7.org/fhir/sid/icd-10"
     snomed: "http://snomed.info/sct"
     ops: "http://fhir.de/CodeSystem/bfarm/ops"
     ucum: "http://unitsofmeasure.org"

--- a/mappings/src/test/java/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.java
+++ b/mappings/src/test/java/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import de.basisdatensatz.obds.v3.OBDS;
 import io.github.bzkf.obdstofhir.FhirProperties;
 import java.io.IOException;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Reference;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -31,7 +32,9 @@ class ConditionMapperTest extends MapperTest {
     "Testpatient_3.xml",
     "Testpatient_leer.xml",
     "Testpatient_Diagnose.xml",
-    "Testpatient_Diagnose_ohne_Version.xml"
+    "Testpatient_Diagnose_ohne_Version.xml",
+    "Testpatient_Diagnose_ICD_WHO.xml",
+    "Testpatient_Diagnose_ICD_Sonstige.xml"
   })
   void map_withGivenObds_shouldCreateValidConditionResource(String sourceFile) throws IOException {
     final var resource = this.getClass().getClassLoader().getResource("obds3/" + sourceFile);
@@ -78,6 +81,50 @@ class ConditionMapperTest extends MapperTest {
             new Reference("Patient/1"),
             obds.getMeldedatum(),
             obdsPatient.getPatientID());
+
+    assertThat(condition.getCode().getText()).isEqualTo(expectedCodeText);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "Testpatient_Diagnose.xml,C50.9,,Mamma-Ca",
+    "Testpatient_Diagnose_ICD_WHO.xml,,C50.9,Mamma-Ca",
+    "Testpatient_Diagnose_ICD_Sonstige.xml,,,C50.9"
+  })
+  void map_withGivenIcdVersion_shouldOnlyAssertTheStatedCatalog(
+      String sourceFile, String expectedGmCode, String expectedWhoCode, String expectedCodeText)
+      throws IOException {
+    final var resource = this.getClass().getClassLoader().getResource("obds3/" + sourceFile);
+    assertThat(resource).isNotNull();
+
+    final var obds = xmlMapper().readValue(resource.openStream(), OBDS.class);
+
+    var obdsPatient = obds.getMengePatient().getPatient().getFirst();
+    var conMeldung =
+        obdsPatient.getMengeMeldung().getMeldung().stream()
+            .filter(m -> m.getDiagnose() != null)
+            .findFirst()
+            .get();
+
+    final var condition =
+        sut.map(
+            conMeldung,
+            new Reference("Patient/1"),
+            obds.getMeldedatum(),
+            obdsPatient.getPatientID());
+
+    var gmCoding =
+        condition.getCode().getCoding().stream()
+            .filter(c -> "http://fhir.de/CodeSystem/bfarm/icd-10-gm".equals(c.getSystem()))
+            .findFirst();
+    assertThat(gmCoding).isPresent();
+    assertThat(gmCoding.get().getCode()).isEqualTo(expectedGmCode);
+
+    var whoCoding =
+        condition.getCode().getCoding().stream()
+            .filter(c -> "http://hl7.org/fhir/sid/icd-10".equals(c.getSystem()))
+            .findFirst();
+    assertThat(whoCoding.map(Coding::getCode).orElse(null)).isEqualTo(expectedWhoCode);
 
     assertThat(condition.getCode().getText()).isEqualTo(expectedCodeText);
   }

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.Testpatient_Diagnose_ICD_Sonstige.xml.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.Testpatient_Diagnose_ICD_Sonstige.xml.approved.fhir.json
@@ -1,0 +1,44 @@
+{
+  "resourceType": "Condition",
+  "id": "6eb2e9a31c56b0664a0b1cd61a2d30568a6b99b3bbd20d5e5a1921c93d5a28bc",
+  "meta": {
+    "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-diagnose-primaertumor" ]
+  },
+  "extension": [ {
+    "url": "http://hl7.org/fhir/StructureDefinition/condition-assertedDate",
+    "valueDateTime": "2020-03-01"
+  } ],
+  "identifier": [ {
+    "system": "https://bzkf.github.io/obds-to-fhir/identifiers/primaerdiagnose-condition-id",
+    "value": "10-101_SONSTIGE"
+  } ],
+  "code": {
+    "coding": [ {
+      "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+      "_version": {
+        "extension": [ {
+          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+          "valueCode": "not-applicable"
+        } ]
+      },
+      "_code": {
+        "extension": [ {
+          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+          "valueCode": "not-applicable"
+        } ]
+      }
+    } ],
+    "text": "C50.9"
+  },
+  "bodySite": [ {
+    "coding": [ {
+      "system": "http://terminology.hl7.org/CodeSystem/icd-o-3",
+      "version": "33",
+      "code": "C50.9"
+    } ]
+  } ],
+  "subject": {
+    "reference": "Patient/1"
+  },
+  "recordedDate": "2024-09-19"
+}

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.Testpatient_Diagnose_ICD_WHO.xml.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ConditionMapperTest.map_withGivenObds_shouldCreateValidConditionResource.Testpatient_Diagnose_ICD_WHO.xml.approved.fhir.json
@@ -1,0 +1,48 @@
+{
+  "resourceType": "Condition",
+  "id": "72e90264b99f91a804f37c0247c12c7f406fa73a6cfd49c4177a2ec41b13b572",
+  "meta": {
+    "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-diagnose-primaertumor" ]
+  },
+  "extension": [ {
+    "url": "http://hl7.org/fhir/StructureDefinition/condition-assertedDate",
+    "valueDateTime": "2020-03-01"
+  } ],
+  "identifier": [ {
+    "system": "https://bzkf.github.io/obds-to-fhir/identifiers/primaerdiagnose-condition-id",
+    "value": "10-101_WHO"
+  } ],
+  "code": {
+    "coding": [ {
+      "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+      "_version": {
+        "extension": [ {
+          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+          "valueCode": "not-applicable"
+        } ]
+      },
+      "_code": {
+        "extension": [ {
+          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+          "valueCode": "not-applicable"
+        } ]
+      }
+    }, {
+      "system": "http://hl7.org/fhir/sid/icd-10",
+      "version": "2020",
+      "code": "C50.9"
+    } ],
+    "text": "Mamma-Ca"
+  },
+  "bodySite": [ {
+    "coding": [ {
+      "system": "http://terminology.hl7.org/CodeSystem/icd-o-3",
+      "version": "33",
+      "code": "C50.9"
+    } ]
+  } ],
+  "subject": {
+    "reference": "Patient/1"
+  },
+  "recordedDate": "2024-09-19"
+}

--- a/mappings/src/test/resources/obds3/Testpatient_Diagnose_ICD_Sonstige.xml
+++ b/mappings/src/test/resources/obds3/Testpatient_Diagnose_ICD_Sonstige.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<oBDS xmlns="http://www.basisdatensatz.de/oBDS/XML"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Schema_Version="3.0.2">
+  <Absender Absender_ID="aA1._/" Software_ID="1" Software_Version="1">
+    <Bezeichnung>Test Absender</Bezeichnung>
+    <Ansprechpartner>Andreas Ansprecher</Ansprechpartner>
+    <Anschrift>Kontaktstraße 1a</Anschrift>
+    <Telefon>+49 (0)69 123456-99</Telefon>
+    <EMail>andreas.ansprecher@testarzt.de</EMail>
+  </Absender>
+  <Meldedatum>2024-09-19</Meldedatum>
+  <Menge_Patient>
+    <Patient Patient_ID="10">
+      <Patienten_Stammdaten>
+        <Versichertendaten_GKV>
+          <IKNR>101097008</IKNR>
+          <GKV_Versichertennummer>A123456780</GKV_Versichertennummer>
+        </Versichertendaten_GKV>
+        <Nachname>Lator</Nachname>
+        <Titel>Dr.</Titel>
+        <Namenszusatz>sen.</Namenszusatz>
+        <Namensvorsatz>von</Namensvorsatz>
+        <Vornamen>Wendy</Vornamen>
+        <Geburtsname>Müller</Geburtsname>
+        <Menge_Frueherer_Name>
+          <Frueherer_Name>Meier</Frueherer_Name>
+        </Menge_Frueherer_Name>
+        <Geschlecht>W</Geschlecht>
+        <Geburtsdatum Datumsgenauigkeit="E">1950-05-01</Geburtsdatum>
+        <Adresse>
+          <Strasse>Hinter dem Horizont</Strasse>
+          <Hausnummer>1a</Hausnummer>
+          <Land>DE</Land>
+          <PLZ>12345</PLZ>
+          <Ort>Hier</Ort>
+        </Adresse>
+      </Patienten_Stammdaten>
+      <Menge_Meldung>
+        <Meldung Melder_ID="123456/abcDEF_:#" Meldung_ID="10_1_DI_SONSTIGE">
+          <Tumorzuordnung Tumor_ID="101_SONSTIGE">
+            <Primaertumor_ICD>
+              <Code>C50.9</Code>
+              <Version>Sonstige</Version>
+            </Primaertumor_ICD>
+            <Diagnosedatum Datumsgenauigkeit="E">2020-03-01</Diagnosedatum>
+          </Tumorzuordnung>
+          <Diagnose>
+            <Primaertumor_Topographie_ICD_O>
+              <Code>C50.9</Code>
+              <Version>33</Version>
+            </Primaertumor_Topographie_ICD_O>
+          </Diagnose>
+          <Anmerkung>Anmerkung zur Meldung!</Anmerkung>
+        </Meldung>
+      </Menge_Meldung>
+    </Patient>
+  </Menge_Patient>
+</oBDS>

--- a/mappings/src/test/resources/obds3/Testpatient_Diagnose_ICD_WHO.xml
+++ b/mappings/src/test/resources/obds3/Testpatient_Diagnose_ICD_WHO.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<oBDS xmlns="http://www.basisdatensatz.de/oBDS/XML"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Schema_Version="3.0.2">
+  <Absender Absender_ID="aA1._/" Software_ID="1" Software_Version="1">
+    <Bezeichnung>Test Absender</Bezeichnung>
+    <Ansprechpartner>Andreas Ansprecher</Ansprechpartner>
+    <Anschrift>Kontaktstraße 1a</Anschrift>
+    <Telefon>+49 (0)69 123456-99</Telefon>
+    <EMail>andreas.ansprecher@testarzt.de</EMail>
+  </Absender>
+  <Meldedatum>2024-09-19</Meldedatum>
+  <Menge_Patient>
+    <Patient Patient_ID="10">
+      <Patienten_Stammdaten>
+        <Versichertendaten_GKV>
+          <IKNR>101097008</IKNR>
+          <GKV_Versichertennummer>A123456780</GKV_Versichertennummer>
+        </Versichertendaten_GKV>
+        <Nachname>Lator</Nachname>
+        <Titel>Dr.</Titel>
+        <Namenszusatz>sen.</Namenszusatz>
+        <Namensvorsatz>von</Namensvorsatz>
+        <Vornamen>Wendy</Vornamen>
+        <Geburtsname>Müller</Geburtsname>
+        <Menge_Frueherer_Name>
+          <Frueherer_Name>Meier</Frueherer_Name>
+        </Menge_Frueherer_Name>
+        <Geschlecht>W</Geschlecht>
+        <Geburtsdatum Datumsgenauigkeit="E">1950-05-01</Geburtsdatum>
+        <Adresse>
+          <Strasse>Hinter dem Horizont</Strasse>
+          <Hausnummer>1a</Hausnummer>
+          <Land>DE</Land>
+          <PLZ>12345</PLZ>
+          <Ort>Hier</Ort>
+        </Adresse>
+      </Patienten_Stammdaten>
+      <Menge_Meldung>
+        <Meldung Melder_ID="123456/abcDEF_:#" Meldung_ID="10_1_DI_WHO">
+          <Tumorzuordnung Tumor_ID="101_WHO">
+            <Primaertumor_ICD>
+              <Code>C50.9</Code>
+              <Version>10 2020 WHO</Version>
+            </Primaertumor_ICD>
+            <Diagnosedatum Datumsgenauigkeit="E">2020-03-01</Diagnosedatum>
+          </Tumorzuordnung>
+          <Diagnose>
+            <Primaertumor_Diagnosetext>Mamma-Ca</Primaertumor_Diagnosetext>
+            <Primaertumor_Topographie_ICD_O>
+              <Code>C50.9</Code>
+              <Version>33</Version>
+            </Primaertumor_Topographie_ICD_O>
+          </Diagnose>
+          <Anmerkung>Anmerkung zur Meldung!</Anmerkung>
+        </Meldung>
+      </Menge_Meldung>
+    </Patient>
+  </Menge_Patient>
+</oBDS>


### PR DESCRIPTION
`ICD_VERSION_PATTERN` matched `10 20xx WHO` and `Sonstige` but dropped the catalogue, so
`Condition.code.coding.system` was set to the ICD-10-GM URI in all three cases — for a WHO input the
resulting `Condition.code` was byte-identical to the GM one.

This follows the way you outlined: the ICD-10-GM coding now carries a `data-absent-reason`
(`not-applicable`) for `code` and `version` unless the source states GM, a WHO input additionally
gets an `http://hl7.org/fhir/sid/icd-10` coding, and `Sonstige` keeps the code in
`Condition.code.text`. An unset or unparsable version is deliberately left on the current behaviour,
and `FruehereTumorerkrankungenMapper` is out of scope here — happy to add either if you want them.
One thing to be aware of: the `icd-regex` invariant on `CodingICD10GM` (de.basisprofil.r4, severity
`warning`) is written as a bare `matches(...)` without an `exists()` guard, so it reports on the
data-absent `code`. Both new snapshots validate with 0 errors.

`./gradlew check` is green (19 + 135 tests, 0 failures): no existing snapshot changed, and two new
oBDS test reports (`WHO` / `Sonstige`) with their snapshots plus a parameterized test on the
resulting codings were added.

Note: #730 touches the same lines of `ConditionMapper`, so whichever of the two merges second needs
a trivial rebase.

Closes #731