### PR TITLE
feat: additionally create Karnofsky Observations

### DIFF
--- a/mappings/src/main/java/io/github/bzkf/obdstofhir/FhirProperties.java
+++ b/mappings/src/main/java/io/github/bzkf/obdstofhir/FhirProperties.java
@@ -58,6 +58,7 @@ public class FhirProperties {
     private String studienteilnahmeObservationId;
     private String lymphknotenuntersuchungObservationId;
     private String allgemeinerLeistungszustandEcogObservationId;
+    private String allgemeinerLeistungszustandKarnofskyObservationId;
     private String genetischeVarianteObservationId;
     private String tumorkonferenzCarePlanId;
     private String tnmGroupingObservationId;

--- a/mappings/src/main/java/io/github/bzkf/obdstofhir/mapper/mii/LeistungszustandMapper.java
+++ b/mappings/src/main/java/io/github/bzkf/obdstofhir/mapper/mii/LeistungszustandMapper.java
@@ -6,8 +6,11 @@ import de.medizininformatikinitiative.kerndatensatz.onkologie.Onkologie;
 import io.github.bzkf.obdstofhir.FhirProperties;
 import io.github.bzkf.obdstofhir.mapper.ObdsToFhirMapper;
 import io.github.dizuker.tofhir.IdUtils;
+import io.github.dizuker.tofhir.ReferenceUtils;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import javax.xml.datatype.XMLGregorianCalendar;
 import org.hl7.fhir.r4.model.*;
 import org.springframework.stereotype.Service;
@@ -19,7 +22,7 @@ public class LeistungszustandMapper extends ObdsToFhirMapper {
     super(fhirProperties);
   }
 
-  public Observation map(
+  public List<Observation> map(
       AllgemeinerLeistungszustand allgemeinerLeistungszustand,
       String meldungsId,
       XMLGregorianCalendar datum,
@@ -29,7 +32,7 @@ public class LeistungszustandMapper extends ObdsToFhirMapper {
     return map(allgemeinerLeistungszustand, meldungsId, date.orElse(null), patient, condition);
   }
 
-  public Observation map(
+  public List<Observation> map(
       AllgemeinerLeistungszustand allgemeinerLeistungszustand,
       String meldungsId,
       DatumTagOderMonatOderJahrOderNichtGenauTyp datum,
@@ -39,7 +42,85 @@ public class LeistungszustandMapper extends ObdsToFhirMapper {
     return map(allgemeinerLeistungszustand, meldungsId, date.orElse(null), patient, condition);
   }
 
-  public Observation map(
+  /**
+   * Maps a Karnofsky performance status to its own Observation. oBDS records ECOG grades and
+   * Karnofsky percentages in the same element, so a Karnofsky input yields this Observation in
+   * addition to the ECOG one; see {@link #map}.
+   *
+   * @return empty if the source recorded an ECOG grade rather than a Karnofsky percentage
+   */
+  private Optional<Observation> mapKarnofsky(
+      AllgemeinerLeistungszustand allgemeinerLeistungszustand,
+      String meldungsId,
+      DateTimeType effective,
+      Reference patient,
+      Reference condition) {
+
+    Objects.requireNonNull(allgemeinerLeistungszustand);
+    Objects.requireNonNull(meldungsId);
+    verifyReference(patient, ResourceType.Patient);
+    verifyReference(condition, ResourceType.Condition);
+
+    var karnofskyValue =
+        Onkologie.CodeSystems.MiiCsOnkoAllgemeinerLeistungszustandKarnofsky.fromValue(
+            allgemeinerLeistungszustand.value());
+    if (karnofskyValue.isEmpty()) {
+      return Optional.empty();
+    }
+
+    var observation = new Observation();
+
+    observation
+        .getMeta()
+        .addProfile(Onkologie.Profiles.miiPrOnkoAllgemeinerLeistungszustandKarnofsky());
+
+    var identifier =
+        new Identifier()
+            .setSystem(
+                fhirProperties
+                    .getSystems()
+                    .getIdentifiers()
+                    .getAllgemeinerLeistungszustandKarnofskyObservationId())
+            .setValue(slugifier.slugify("KARNOFSKY-" + meldungsId));
+    observation.addIdentifier(identifier);
+    observation.setId(IdUtils.fromIdentifier(identifier));
+
+    observation.setSubject(patient);
+
+    observation.setStatus(Observation.ObservationStatus.FINAL);
+
+    var codeConcept = new CodeableConcept();
+    codeConcept.addCoding(
+        fhirProperties
+            .getCodings()
+            .snomed()
+            .setCode("761869008")
+            .setDisplay("Karnofsky Performance Status score (observable entity)"));
+    codeConcept.addCoding(
+        fhirProperties
+            .getCodings()
+            .loinc()
+            .setCode("89243-0")
+            .setDisplay("Karnofsky Performance Status score"));
+
+    observation.setCode(codeConcept);
+
+    observation.setEffective(effective);
+
+    observation.setFocus(Collections.singletonList(condition));
+
+    observation.setValue(new CodeableConcept().addCoding(karnofskyValue.get().coding()));
+
+    return Optional.of(observation);
+  }
+
+  /**
+   * Maps an oBDS performance status to its FHIR Observations.
+   *
+   * @return the ECOG Observation alone if the source recorded an ECOG grade; the ECOG Observation
+   *     and the Karnofsky Observation it derives from if the source recorded a Karnofsky percentage
+   */
+  public List<Observation> map(
       AllgemeinerLeistungszustand allgemeinerLeistungszustand,
       String meldungsId,
       DateTimeType effective,
@@ -142,6 +223,13 @@ public class LeistungszustandMapper extends ObdsToFhirMapper {
 
     observation.setValue(valueConcept);
 
-    return observation;
+    var karnofsky =
+        mapKarnofsky(allgemeinerLeistungszustand, meldungsId, effective, patient, condition);
+    if (karnofsky.isEmpty()) {
+      return List.of(observation);
+    }
+
+    observation.setDerivedFrom(List.of(ReferenceUtils.createReferenceTo(karnofsky.get())));
+    return List.of(observation, karnofsky.get());
   }
 }

--- a/mappings/src/main/java/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapper.java
+++ b/mappings/src/main/java/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapper.java
@@ -564,14 +564,13 @@ public class ObdsToFhirBundleMapper extends ObdsToFhirMapper {
     var primaryConditionReference = ReferenceUtils.createReferenceTo(primaryCondition);
 
     if (diagnose.getAllgemeinerLeistungszustand() != null) {
-      var leistungszustand =
+      mappedResources.addAll(
           leistungszustandMapper.map(
               diagnose.getAllgemeinerLeistungszustand(),
               meldung.getMeldungID(),
               meldung.getTumorzuordnung().getDiagnosedatum(),
               patientReference,
-              primaryConditionReference);
-      mappedResources.add(leistungszustand);
+              primaryConditionReference));
     }
 
     if (diagnose.getMengeFM() != null && diagnose.getMengeFM().getFernmetastase() != null) {
@@ -728,14 +727,13 @@ public class ObdsToFhirBundleMapper extends ObdsToFhirMapper {
     }
 
     if (verlauf.getAllgemeinerLeistungszustand() != null) {
-      var leistungszustand =
+      mappedResources.addAll(
           leistungszustandMapper.map(
               verlauf.getAllgemeinerLeistungszustand(),
               meldung.getMeldungID(),
               verlauf.getUntersuchungsdatumVerlauf(),
               patientReference,
-              primaryConditionReference);
-      mappedResources.add(leistungszustand);
+              primaryConditionReference));
     }
 
     if (verlauf.getHistologie() != null) {

--- a/mappings/src/main/resources/application-mappings.yml
+++ b/mappings/src/main/resources/application-mappings.yml
@@ -38,6 +38,7 @@ fhir:
       systemische-therapie-medication-statement-id: "${fhir.systems.identifiers.base-url}/systemische-therapie-medication-statement-id"
       systemische-therapie-medication-id: "${fhir.systems.identifiers.base-url}/systemische-therapie-medication-id"
       allgemeiner-leistungszustand-ecog-observation-id: "${fhir.systems.identifiers.base-url}/allgemeiner-leistungszustand-ecog-id"
+      allgemeiner-leistungszustand-karnofsky-observation-id: "${fhir.systems.identifiers.base-url}/allgemeiner-leistungszustand-karnofsky-id"
       fernmetastasen-observation-id: "${fhir.systems.identifiers.base-url}/fernmetastasen-observation-id"
       residualstatus-observation-id: "${fhir.systems.identifiers.base-url}/residualstatus-observation-id"
       histologiebefund-diagnostic-report-id: "${fhir.systems.identifiers.base-url}/histologiebefund-diagnostic-report-id"

--- a/mappings/src/test/java/io/github/bzkf/obdstofhir/mapper/mii/LeistungszustandMapperTest.java
+++ b/mappings/src/test/java/io/github/bzkf/obdstofhir/mapper/mii/LeistungszustandMapperTest.java
@@ -1,10 +1,12 @@
 package io.github.bzkf.obdstofhir.mapper.mii;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import de.basisdatensatz.obds.v3.AllgemeinerLeistungszustand;
 import de.basisdatensatz.obds.v3.OBDS;
 import io.github.bzkf.obdstofhir.FhirProperties;
 import java.io.IOException;
+import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Reference;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,6 +51,72 @@ class LeistungszustandMapperTest extends MapperTest {
             new Reference("Patient/1"),
             new Reference("Condition/Primärdiagnose"));
 
-    verify(leistungszustand, sourceFile);
+    verify(leistungszustand.getFirst(), sourceFile);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "ECOG_0,",
+    "ECOG_4,",
+    "U,",
+    "KARNOFSKY_10,10%",
+    "KARNOFSKY_70,70%",
+    "KARNOFSKY_100,100%"
+  })
+  void map_shouldOnlyCreateKarnofskyObservationForKarnofskyValues(
+      AllgemeinerLeistungszustand leistungszustand, String expectedCode) {
+    final var observations =
+        sut.map(
+            leistungszustand,
+            "10_1_VE-1",
+            (DateTimeType) null,
+            new Reference("Patient/1"),
+            new Reference("Condition/Primärdiagnose"));
+
+    if (expectedCode == null) {
+      assertThat(observations).hasSize(1);
+      assertThat(observations.getFirst().hasDerivedFrom()).isFalse();
+      return;
+    }
+
+    assertThat(observations).hasSize(2);
+
+    final var karnofsky = observations.get(1);
+    assertThat(karnofsky.getValueCodeableConcept().getCodingFirstRep().getCode())
+        .isEqualTo(expectedCode);
+
+    final var ecog = observations.getFirst();
+    assertThat(ecog.getDerivedFromFirstRep().getReference())
+        .isEqualTo("Observation/" + karnofsky.getIdPart());
+  }
+
+  @ParameterizedTest
+  @CsvSource({"Testpatient_1.xml", "Testpatient_3.xml"})
+  void map_withKarnofskyInput_shouldAlsoCreateKarnofskyObservation(String sourceFile)
+      throws IOException {
+    final var resource = this.getClass().getClassLoader().getResource("obds3/" + sourceFile);
+    assertThat(resource).isNotNull();
+
+    final var obds = xmlMapper().readValue(resource.openStream(), OBDS.class);
+
+    var obdsPatient = obds.getMengePatient().getPatient().getFirst();
+    var verlaufMeldungOptional =
+        obdsPatient.getMengeMeldung().getMeldung().stream()
+            .filter(m -> m.getVerlauf() != null)
+            .filter(m -> m.getVerlauf().getAllgemeinerLeistungszustand() != null)
+            .findFirst();
+    assertThat(verlaufMeldungOptional).isPresent();
+    var verlaufMeldung = verlaufMeldungOptional.get();
+
+    final var observations =
+        sut.map(
+            verlaufMeldung.getVerlauf().getAllgemeinerLeistungszustand(),
+            verlaufMeldung.getMeldungID(),
+            verlaufMeldung.getVerlauf().getUntersuchungsdatumVerlauf(),
+            new Reference("Patient/1"),
+            new Reference("Condition/Primärdiagnose"));
+
+    assertThat(observations).hasSize(2);
+    verify(observations.get(1), sourceFile);
   }
 }

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/LeistungszustandMapperTest.map_withKarnofskyInput_shouldAlsoCreateKarnofskyObservation.Testpatient_1.xml.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/LeistungszustandMapperTest.map_withKarnofskyInput_shouldAlsoCreateKarnofskyObservation.Testpatient_1.xml.approved.fhir.json
@@ -1,0 +1,39 @@
+{
+  "resourceType": "Observation",
+  "id": "fd7cd2158c1dab8d6cc9c128b00ebf6476374be5c5c8596b00c41ff340ae8829",
+  "meta": {
+    "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-allgemeiner-leistungszustand-karnofsky" ]
+  },
+  "identifier": [ {
+    "system": "https://bzkf.github.io/obds-to-fhir/identifiers/allgemeiner-leistungszustand-karnofsky-id",
+    "value": "KARNOFSKY-10_1_VE-1"
+  } ],
+  "status": "final",
+  "code": {
+    "coding": [ {
+      "system": "http://snomed.info/sct",
+      "version": "http://snomed.info/sct/900000000000207008/version/20250701",
+      "code": "761869008",
+      "display": "Karnofsky Performance Status score (observable entity)"
+    }, {
+      "system": "http://loinc.org",
+      "version": "2.82",
+      "code": "89243-0",
+      "display": "Karnofsky Performance Status score"
+    } ]
+  },
+  "subject": {
+    "reference": "Patient/1"
+  },
+  "focus": [ {
+    "reference": "Condition/Primärdiagnose"
+  } ],
+  "effectiveDateTime": "2021-06-01",
+  "valueCodeableConcept": {
+    "coding": [ {
+      "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-allgemeiner-leistungszustand-karnofsky",
+      "code": "20%",
+      "display": "20%"
+    } ]
+  }
+}

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/LeistungszustandMapperTest.map_withKarnofskyInput_shouldAlsoCreateKarnofskyObservation.Testpatient_3.xml.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/LeistungszustandMapperTest.map_withKarnofskyInput_shouldAlsoCreateKarnofskyObservation.Testpatient_3.xml.approved.fhir.json
@@ -1,0 +1,39 @@
+{
+  "resourceType": "Observation",
+  "id": "3198d91f2171c35b2d89e9897f4f196604e7a6fc025d0744206f31b569071633",
+  "meta": {
+    "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-allgemeiner-leistungszustand-karnofsky" ]
+  },
+  "identifier": [ {
+    "system": "https://bzkf.github.io/obds-to-fhir/identifiers/allgemeiner-leistungszustand-karnofsky-id",
+    "value": "KARNOFSKY-12_1_VE_1"
+  } ],
+  "status": "final",
+  "code": {
+    "coding": [ {
+      "system": "http://snomed.info/sct",
+      "version": "http://snomed.info/sct/900000000000207008/version/20250701",
+      "code": "761869008",
+      "display": "Karnofsky Performance Status score (observable entity)"
+    }, {
+      "system": "http://loinc.org",
+      "version": "2.82",
+      "code": "89243-0",
+      "display": "Karnofsky Performance Status score"
+    } ]
+  },
+  "subject": {
+    "reference": "Patient/1"
+  },
+  "focus": [ {
+    "reference": "Condition/Primärdiagnose"
+  } ],
+  "effectiveDateTime": "2018-06-02",
+  "valueCodeableConcept": {
+    "coding": [ {
+      "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-allgemeiner-leistungszustand-karnofsky",
+      "code": "60%",
+      "display": "60%"
+    } ]
+  }
+}

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.0.approved.fhir.json
@@ -1294,11 +1294,63 @@
           "code": "LA9626-8",
           "display": "Completely disabled. Cannot carry on any selfcare. Totally confined to bed or chair"
         } ]
-      }
+      },
+      "derivedFrom": [ {
+        "reference": "Observation/4adea244fa97200e4151c75b3a5eb72853c093d8b36cb48843cf65eb6be368ba"
+      } ]
     },
     "request": {
       "method": "PUT",
       "url": "Observation/571d00c58bfaa0b922814f1f2bfb644f5b7788958b4cdb9e5b00e802fb5135ad"
+    }
+  }, {
+    "fullUrl": "Observation/4adea244fa97200e4151c75b3a5eb72853c093d8b36cb48843cf65eb6be368ba",
+    "resource": {
+      "resourceType": "Observation",
+      "id": "4adea244fa97200e4151c75b3a5eb72853c093d8b36cb48843cf65eb6be368ba",
+      "meta": {
+        "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-allgemeiner-leistungszustand-karnofsky" ]
+      },
+      "identifier": [ {
+        "system": "https://bzkf.github.io/obds-to-fhir/identifiers/allgemeiner-leistungszustand-karnofsky-id",
+        "value": "KARNOFSKY-10_1_VE-2"
+      } ],
+      "status": "final",
+      "code": {
+        "coding": [ {
+          "system": "http://snomed.info/sct",
+          "version": "http://snomed.info/sct/900000000000207008/version/20250701",
+          "code": "761869008",
+          "display": "Karnofsky Performance Status score (observable entity)"
+        }, {
+          "system": "http://loinc.org",
+          "version": "2.82",
+          "code": "89243-0",
+          "display": "Karnofsky Performance Status score"
+        } ]
+      },
+      "subject": {
+        "reference": "Patient/a02e16474896f1d528cac71f2c9b4c45ac3c9028e3a53fb414a1f7882991ee07",
+        "identifier": {
+          "system": "https://bzkf.github.io/obds-to-fhir/identifiers/patient-id",
+          "value": "10"
+        }
+      },
+      "focus": [ {
+        "reference": "Condition/528cbfb627eff7b031c902f2a97d149f5640d57a28f705fadba22462aae7c408"
+      } ],
+      "effectiveDateTime": "2021-12-02",
+      "valueCodeableConcept": {
+        "coding": [ {
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-allgemeiner-leistungszustand-karnofsky",
+          "code": "10%",
+          "display": "10%"
+        } ]
+      }
+    },
+    "request": {
+      "method": "PUT",
+      "url": "Observation/4adea244fa97200e4151c75b3a5eb72853c093d8b36cb48843cf65eb6be368ba"
     }
   }, {
     "fullUrl": "Observation/d0839b6f7b1989120593c988e21f4271a5a01622b5f14cfc12f485d8f98fd1e8",
@@ -3006,11 +3058,63 @@
           "code": "LA9626-8",
           "display": "Completely disabled. Cannot carry on any selfcare. Totally confined to bed or chair"
         } ]
-      }
+      },
+      "derivedFrom": [ {
+        "reference": "Observation/fd7cd2158c1dab8d6cc9c128b00ebf6476374be5c5c8596b00c41ff340ae8829"
+      } ]
     },
     "request": {
       "method": "PUT",
       "url": "Observation/1b8cbcab8427f3d4b77c4814ec9e7aa065916dc5734f77115fccbf4cdcd44a2b"
+    }
+  }, {
+    "fullUrl": "Observation/fd7cd2158c1dab8d6cc9c128b00ebf6476374be5c5c8596b00c41ff340ae8829",
+    "resource": {
+      "resourceType": "Observation",
+      "id": "fd7cd2158c1dab8d6cc9c128b00ebf6476374be5c5c8596b00c41ff340ae8829",
+      "meta": {
+        "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-allgemeiner-leistungszustand-karnofsky" ]
+      },
+      "identifier": [ {
+        "system": "https://bzkf.github.io/obds-to-fhir/identifiers/allgemeiner-leistungszustand-karnofsky-id",
+        "value": "KARNOFSKY-10_1_VE-1"
+      } ],
+      "status": "final",
+      "code": {
+        "coding": [ {
+          "system": "http://snomed.info/sct",
+          "version": "http://snomed.info/sct/900000000000207008/version/20250701",
+          "code": "761869008",
+          "display": "Karnofsky Performance Status score (observable entity)"
+        }, {
+          "system": "http://loinc.org",
+          "version": "2.82",
+          "code": "89243-0",
+          "display": "Karnofsky Performance Status score"
+        } ]
+      },
+      "subject": {
+        "reference": "Patient/a02e16474896f1d528cac71f2c9b4c45ac3c9028e3a53fb414a1f7882991ee07",
+        "identifier": {
+          "system": "https://bzkf.github.io/obds-to-fhir/identifiers/patient-id",
+          "value": "10"
+        }
+      },
+      "focus": [ {
+        "reference": "Condition/528cbfb627eff7b031c902f2a97d149f5640d57a28f705fadba22462aae7c408"
+      } ],
+      "effectiveDateTime": "2021-06-01",
+      "valueCodeableConcept": {
+        "coding": [ {
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-allgemeiner-leistungszustand-karnofsky",
+          "code": "20%",
+          "display": "20%"
+        } ]
+      }
+    },
+    "request": {
+      "method": "PUT",
+      "url": "Observation/fd7cd2158c1dab8d6cc9c128b00ebf6476374be5c5c8596b00c41ff340ae8829"
     }
   }, {
     "fullUrl": "Specimen/dbaa556b11c59ff24efb94a652a9574e63de84b972e2caa8bf60b3d8e4ada2fb",

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_3.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperTest/map_withGivenObds_shouldCreateBundleMatchingSnapshot.Testpatient_3.xml.0.approved.fhir.json
@@ -656,11 +656,63 @@
           "code": "LA9624-3",
           "display": "Ambulatory and capable of all selfcare but unable to carry out any work activities. Up and about more than 50% of waking hours"
         } ]
-      }
+      },
+      "derivedFrom": [ {
+        "reference": "Observation/3198d91f2171c35b2d89e9897f4f196604e7a6fc025d0744206f31b569071633"
+      } ]
     },
     "request": {
       "method": "PUT",
       "url": "Observation/e7950487ad664f6ad1245f805c59d22d06ef2a0ad923901f680e3fa577965122"
+    }
+  }, {
+    "fullUrl": "Observation/3198d91f2171c35b2d89e9897f4f196604e7a6fc025d0744206f31b569071633",
+    "resource": {
+      "resourceType": "Observation",
+      "id": "3198d91f2171c35b2d89e9897f4f196604e7a6fc025d0744206f31b569071633",
+      "meta": {
+        "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-allgemeiner-leistungszustand-karnofsky" ]
+      },
+      "identifier": [ {
+        "system": "https://bzkf.github.io/obds-to-fhir/identifiers/allgemeiner-leistungszustand-karnofsky-id",
+        "value": "KARNOFSKY-12_1_VE_1"
+      } ],
+      "status": "final",
+      "code": {
+        "coding": [ {
+          "system": "http://snomed.info/sct",
+          "version": "http://snomed.info/sct/900000000000207008/version/20250701",
+          "code": "761869008",
+          "display": "Karnofsky Performance Status score (observable entity)"
+        }, {
+          "system": "http://loinc.org",
+          "version": "2.82",
+          "code": "89243-0",
+          "display": "Karnofsky Performance Status score"
+        } ]
+      },
+      "subject": {
+        "reference": "Patient/6f5a4631aa1afa9fb3b290f6bb86163ea01f9b24bd1170e5d79a0c36995c2c57",
+        "identifier": {
+          "system": "https://bzkf.github.io/obds-to-fhir/identifiers/patient-id",
+          "value": "12"
+        }
+      },
+      "focus": [ {
+        "reference": "Condition/c4396ca95fdae137b54465873fe2ccc7e7e2f5bb6b0c3edc3cc9bb59581f531c"
+      } ],
+      "effectiveDateTime": "2018-06-02",
+      "valueCodeableConcept": {
+        "coding": [ {
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-allgemeiner-leistungszustand-karnofsky",
+          "code": "60%",
+          "display": "60%"
+        } ]
+      }
+    },
+    "request": {
+      "method": "PUT",
+      "url": "Observation/3198d91f2171c35b2d89e9897f4f196604e7a6fc025d0744206f31b569071633"
     }
   }, {
     "fullUrl": "Observation/66d516595ce02c44d0a0a4468e65f29af40fea407465cacaea88f617e37d2ac4",

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperWithPatientIdRegexSetTest/map_withGivenObdsAndPatientIdRegex_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperWithPatientIdRegexSetTest/map_withGivenObdsAndPatientIdRegex_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.0.approved.fhir.json
@@ -1294,11 +1294,63 @@
           "code": "LA9626-8",
           "display": "Completely disabled. Cannot carry on any selfcare. Totally confined to bed or chair"
         } ]
-      }
+      },
+      "derivedFrom": [ {
+        "reference": "Observation/4adea244fa97200e4151c75b3a5eb72853c093d8b36cb48843cf65eb6be368ba"
+      } ]
     },
     "request": {
       "method": "PUT",
       "url": "Observation/571d00c58bfaa0b922814f1f2bfb644f5b7788958b4cdb9e5b00e802fb5135ad"
+    }
+  }, {
+    "fullUrl": "Observation/4adea244fa97200e4151c75b3a5eb72853c093d8b36cb48843cf65eb6be368ba",
+    "resource": {
+      "resourceType": "Observation",
+      "id": "4adea244fa97200e4151c75b3a5eb72853c093d8b36cb48843cf65eb6be368ba",
+      "meta": {
+        "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-allgemeiner-leistungszustand-karnofsky" ]
+      },
+      "identifier": [ {
+        "system": "https://bzkf.github.io/obds-to-fhir/identifiers/allgemeiner-leistungszustand-karnofsky-id",
+        "value": "KARNOFSKY-10_1_VE-2"
+      } ],
+      "status": "final",
+      "code": {
+        "coding": [ {
+          "system": "http://snomed.info/sct",
+          "version": "http://snomed.info/sct/900000000000207008/version/20250701",
+          "code": "761869008",
+          "display": "Karnofsky Performance Status score (observable entity)"
+        }, {
+          "system": "http://loinc.org",
+          "version": "2.82",
+          "code": "89243-0",
+          "display": "Karnofsky Performance Status score"
+        } ]
+      },
+      "subject": {
+        "reference": "Patient/7d3abf49fed5ada2b7ab4ee9b17d0ed448ea32d52209907b1a13030594565149",
+        "identifier": {
+          "system": "https://bzkf.github.io/obds-to-fhir/identifiers/patient-id",
+          "value": "1"
+        }
+      },
+      "focus": [ {
+        "reference": "Condition/3bf7a62876e91710228794a459051653ef1ec4ab1194f664be85e2f4dba0c131"
+      } ],
+      "effectiveDateTime": "2021-12-02",
+      "valueCodeableConcept": {
+        "coding": [ {
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-allgemeiner-leistungszustand-karnofsky",
+          "code": "10%",
+          "display": "10%"
+        } ]
+      }
+    },
+    "request": {
+      "method": "PUT",
+      "url": "Observation/4adea244fa97200e4151c75b3a5eb72853c093d8b36cb48843cf65eb6be368ba"
     }
   }, {
     "fullUrl": "Observation/0b3408d46b20d75174e678b7137c6d9d6d9a94d357a80970fee7d82996462093",
@@ -3006,11 +3058,63 @@
           "code": "LA9626-8",
           "display": "Completely disabled. Cannot carry on any selfcare. Totally confined to bed or chair"
         } ]
-      }
+      },
+      "derivedFrom": [ {
+        "reference": "Observation/fd7cd2158c1dab8d6cc9c128b00ebf6476374be5c5c8596b00c41ff340ae8829"
+      } ]
     },
     "request": {
       "method": "PUT",
       "url": "Observation/1b8cbcab8427f3d4b77c4814ec9e7aa065916dc5734f77115fccbf4cdcd44a2b"
+    }
+  }, {
+    "fullUrl": "Observation/fd7cd2158c1dab8d6cc9c128b00ebf6476374be5c5c8596b00c41ff340ae8829",
+    "resource": {
+      "resourceType": "Observation",
+      "id": "fd7cd2158c1dab8d6cc9c128b00ebf6476374be5c5c8596b00c41ff340ae8829",
+      "meta": {
+        "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-allgemeiner-leistungszustand-karnofsky" ]
+      },
+      "identifier": [ {
+        "system": "https://bzkf.github.io/obds-to-fhir/identifiers/allgemeiner-leistungszustand-karnofsky-id",
+        "value": "KARNOFSKY-10_1_VE-1"
+      } ],
+      "status": "final",
+      "code": {
+        "coding": [ {
+          "system": "http://snomed.info/sct",
+          "version": "http://snomed.info/sct/900000000000207008/version/20250701",
+          "code": "761869008",
+          "display": "Karnofsky Performance Status score (observable entity)"
+        }, {
+          "system": "http://loinc.org",
+          "version": "2.82",
+          "code": "89243-0",
+          "display": "Karnofsky Performance Status score"
+        } ]
+      },
+      "subject": {
+        "reference": "Patient/7d3abf49fed5ada2b7ab4ee9b17d0ed448ea32d52209907b1a13030594565149",
+        "identifier": {
+          "system": "https://bzkf.github.io/obds-to-fhir/identifiers/patient-id",
+          "value": "1"
+        }
+      },
+      "focus": [ {
+        "reference": "Condition/3bf7a62876e91710228794a459051653ef1ec4ab1194f664be85e2f4dba0c131"
+      } ],
+      "effectiveDateTime": "2021-06-01",
+      "valueCodeableConcept": {
+        "coding": [ {
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-allgemeiner-leistungszustand-karnofsky",
+          "code": "20%",
+          "display": "20%"
+        } ]
+      }
+    },
+    "request": {
+      "method": "PUT",
+      "url": "Observation/fd7cd2158c1dab8d6cc9c128b00ebf6476374be5c5c8596b00c41ff340ae8829"
     }
   }, {
     "fullUrl": "Specimen/dbaa556b11c59ff24efb94a652a9574e63de84b972e2caa8bf60b3d8e4ada2fb",

--- a/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperWithProvenanceEnabledTest/map_withGivenObdsAndEnabledProvenance_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.0.approved.fhir.json
+++ b/mappings/src/test/java/snapshots/io/github/bzkf/obdstofhir/mapper/mii/ObdsToFhirBundleMapperWithProvenanceEnabledTest/map_withGivenObdsAndEnabledProvenance_shouldCreateBundleMatchingSnapshot.Testpatient_1.xml.0.approved.fhir.json
@@ -1386,11 +1386,63 @@
           "code": "LA9626-8",
           "display": "Completely disabled. Cannot carry on any selfcare. Totally confined to bed or chair"
         } ]
-      }
+      },
+      "derivedFrom": [ {
+        "reference": "Observation/4adea244fa97200e4151c75b3a5eb72853c093d8b36cb48843cf65eb6be368ba"
+      } ]
     },
     "request": {
       "method": "PUT",
       "url": "Observation/571d00c58bfaa0b922814f1f2bfb644f5b7788958b4cdb9e5b00e802fb5135ad"
+    }
+  }, {
+    "fullUrl": "Observation/4adea244fa97200e4151c75b3a5eb72853c093d8b36cb48843cf65eb6be368ba",
+    "resource": {
+      "resourceType": "Observation",
+      "id": "4adea244fa97200e4151c75b3a5eb72853c093d8b36cb48843cf65eb6be368ba",
+      "meta": {
+        "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-allgemeiner-leistungszustand-karnofsky" ]
+      },
+      "identifier": [ {
+        "system": "https://bzkf.github.io/obds-to-fhir/identifiers/allgemeiner-leistungszustand-karnofsky-id",
+        "value": "KARNOFSKY-10_1_VE-2"
+      } ],
+      "status": "final",
+      "code": {
+        "coding": [ {
+          "system": "http://snomed.info/sct",
+          "version": "http://snomed.info/sct/900000000000207008/version/20250701",
+          "code": "761869008",
+          "display": "Karnofsky Performance Status score (observable entity)"
+        }, {
+          "system": "http://loinc.org",
+          "version": "2.82",
+          "code": "89243-0",
+          "display": "Karnofsky Performance Status score"
+        } ]
+      },
+      "subject": {
+        "reference": "Patient/a02e16474896f1d528cac71f2c9b4c45ac3c9028e3a53fb414a1f7882991ee07",
+        "identifier": {
+          "system": "https://bzkf.github.io/obds-to-fhir/identifiers/patient-id",
+          "value": "10"
+        }
+      },
+      "focus": [ {
+        "reference": "Condition/528cbfb627eff7b031c902f2a97d149f5640d57a28f705fadba22462aae7c408"
+      } ],
+      "effectiveDateTime": "2021-12-02",
+      "valueCodeableConcept": {
+        "coding": [ {
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-allgemeiner-leistungszustand-karnofsky",
+          "code": "10%",
+          "display": "10%"
+        } ]
+      }
+    },
+    "request": {
+      "method": "PUT",
+      "url": "Observation/4adea244fa97200e4151c75b3a5eb72853c093d8b36cb48843cf65eb6be368ba"
     }
   }, {
     "fullUrl": "Provenance/a420293260e0fcef49e30a7ee33fa1a8d8a8bca9f7cbb1c20030acf234e3b9c6",
@@ -1403,6 +1455,8 @@
         "reference": "Observation/9e62e963fe7db78a3925d720c66f66de6674abdfe535f6c08b5a4a9ef5379743"
       }, {
         "reference": "Observation/571d00c58bfaa0b922814f1f2bfb644f5b7788958b4cdb9e5b00e802fb5135ad"
+      }, {
+        "reference": "Observation/4adea244fa97200e4151c75b3a5eb72853c093d8b36cb48843cf65eb6be368ba"
       } ],
       "occurredDateTime": "2000-01-01T11:11:11Z",
       "recorded": "2000-01-01T11:11:11Z",
@@ -3524,11 +3578,63 @@
           "code": "LA9626-8",
           "display": "Completely disabled. Cannot carry on any selfcare. Totally confined to bed or chair"
         } ]
-      }
+      },
+      "derivedFrom": [ {
+        "reference": "Observation/fd7cd2158c1dab8d6cc9c128b00ebf6476374be5c5c8596b00c41ff340ae8829"
+      } ]
     },
     "request": {
       "method": "PUT",
       "url": "Observation/1b8cbcab8427f3d4b77c4814ec9e7aa065916dc5734f77115fccbf4cdcd44a2b"
+    }
+  }, {
+    "fullUrl": "Observation/fd7cd2158c1dab8d6cc9c128b00ebf6476374be5c5c8596b00c41ff340ae8829",
+    "resource": {
+      "resourceType": "Observation",
+      "id": "fd7cd2158c1dab8d6cc9c128b00ebf6476374be5c5c8596b00c41ff340ae8829",
+      "meta": {
+        "profile": [ "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/StructureDefinition/mii-pr-onko-allgemeiner-leistungszustand-karnofsky" ]
+      },
+      "identifier": [ {
+        "system": "https://bzkf.github.io/obds-to-fhir/identifiers/allgemeiner-leistungszustand-karnofsky-id",
+        "value": "KARNOFSKY-10_1_VE-1"
+      } ],
+      "status": "final",
+      "code": {
+        "coding": [ {
+          "system": "http://snomed.info/sct",
+          "version": "http://snomed.info/sct/900000000000207008/version/20250701",
+          "code": "761869008",
+          "display": "Karnofsky Performance Status score (observable entity)"
+        }, {
+          "system": "http://loinc.org",
+          "version": "2.82",
+          "code": "89243-0",
+          "display": "Karnofsky Performance Status score"
+        } ]
+      },
+      "subject": {
+        "reference": "Patient/a02e16474896f1d528cac71f2c9b4c45ac3c9028e3a53fb414a1f7882991ee07",
+        "identifier": {
+          "system": "https://bzkf.github.io/obds-to-fhir/identifiers/patient-id",
+          "value": "10"
+        }
+      },
+      "focus": [ {
+        "reference": "Condition/528cbfb627eff7b031c902f2a97d149f5640d57a28f705fadba22462aae7c408"
+      } ],
+      "effectiveDateTime": "2021-06-01",
+      "valueCodeableConcept": {
+        "coding": [ {
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/CodeSystem/mii-cs-onko-allgemeiner-leistungszustand-karnofsky",
+          "code": "20%",
+          "display": "20%"
+        } ]
+      }
+    },
+    "request": {
+      "method": "PUT",
+      "url": "Observation/fd7cd2158c1dab8d6cc9c128b00ebf6476374be5c5c8596b00c41ff340ae8829"
     }
   }, {
     "fullUrl": "Specimen/dbaa556b11c59ff24efb94a652a9574e63de84b972e2caa8bf60b3d8e4ada2fb",
@@ -4404,6 +4510,8 @@
         "reference": "Observation/82668baaffb56a64c1463dd5d7c772361838c2a958179976dd18c65599882faf"
       }, {
         "reference": "Observation/1b8cbcab8427f3d4b77c4814ec9e7aa065916dc5734f77115fccbf4cdcd44a2b"
+      }, {
+        "reference": "Observation/fd7cd2158c1dab8d6cc9c128b00ebf6476374be5c5c8596b00c41ff340ae8829"
       }, {
         "reference": "Specimen/dbaa556b11c59ff24efb94a652a9574e63de84b972e2caa8bf60b3d8e4ada2fb"
       }, {


### PR DESCRIPTION
oBDS records ECOG grades and Karnofsky percentages in the same `Allgemeiner_Leistungszustand`
element and both are mapped to an ECOG Observation, so the output keeps no trace of which of the two
the source used.

The ECOG mapping is untouched — the decision in #185 stands — and a Karnofsky input now
additionally produces an `mii-pr-onko-allgemeiner-leistungszustand-karnofsky` Observation
(SNOMED `761869008` / LOINC `89243-0`, value from
`mii-cs-onko-allgemeiner-leistungszustand-karnofsky`). The value carries the MII coding only; if you
would like the LOINC answer codes as well, `mii-cm-onko-allgemeiner-leistungszustand-karnofsky-loinc`
has them and I will add them.

`./gradlew check` is green (19 + 138 tests, 0 failures): the four affected bundle snapshots changed
purely additively (0 lines removed, ECOG resource count unchanged at 7 and 2), there are two new
Observation snapshots, and a parameterized test asserts that every ECOG value yields no Karnofsky
Observation.

Closes #729